### PR TITLE
Allow Override of Detect Version Used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,8 @@ build {
         def shellScriptTemplateFile = new File("${projectDir}/src/main/resources/hub-detect-sh")
         def shellScriptContents = shellScriptTemplateFile.getText('UTF-8')
         if (!version.contains('SNAPSHOT')) {
-            shellScriptContents = shellScriptContents.replaceFirst("DETECT_LATEST_RELEASE_VERSION=\\S*\n", 'DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-' + "${version}" + '}\n')
+            String latestReleaseVersion = 'DETECT_LATEST_RELEASE_VERSION=\\${DETECT_LATEST_RELEASE_VERSION:-' + "${version}" + '}\n'
+            shellScriptContents = shellScriptContents.replaceFirst("DETECT_LATEST_RELEASE_VERSION=\\S*\n", latestReleaseVersion)
             shellScriptTemplateFile.delete()
             shellScriptTemplateFile << shellScriptContents
         }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ build {
         def shellScriptTemplateFile = new File("${projectDir}/src/main/resources/hub-detect-sh")
         def shellScriptContents = shellScriptTemplateFile.getText('UTF-8')
         if (!version.contains('SNAPSHOT')) {
-            shellScriptContents = shellScriptContents.replaceFirst("DETECT_LATEST_RELEASE_VERSION=\\S*\n", "DETECT_LATEST_RELEASE_VERSION=\"${version}\"\n")
+            shellScriptContents = shellScriptContents.replaceFirst("DETECT_LATEST_RELEASE_VERSION=\\S*\n", 'DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-' + "${version}" + '}\n')
             shellScriptTemplateFile.delete()
             shellScriptTemplateFile << shellScriptContents
         }

--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -8,7 +8,7 @@ DETECT_LATEST_SNAPSHOT=hub-detect-latest-SNAPSHOT.jar
 
 # This value should be automatically updated by the
 # gradle build process for a non-snapshot build.
-DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-1.1.0}
+DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-1.0.0}
 DETECT_LATEST_RELEASE="hub-detect-${DETECT_LATEST_RELEASE_VERSION}.jar"
 
 # If you would like to enable the shell script to use

--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -8,7 +8,7 @@ DETECT_LATEST_SNAPSHOT=hub-detect-latest-SNAPSHOT.jar
 
 # This value should be automatically updated by the
 # gradle build process for a non-snapshot build.
-DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-1.0.0}
+DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-1.1.0}
 DETECT_LATEST_RELEASE="hub-detect-${DETECT_LATEST_RELEASE_VERSION}.jar"
 
 # If you would like to enable the shell script to use

--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -8,7 +8,7 @@ DETECT_LATEST_SNAPSHOT=hub-detect-latest-SNAPSHOT.jar
 
 # This value should be automatically updated by the
 # gradle build process for a non-snapshot build.
-DETECT_LATEST_RELEASE_VERSION="1.0.0"
+DETECT_LATEST_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION:-1.0.0}
 DETECT_LATEST_RELEASE="hub-detect-${DETECT_LATEST_RELEASE_VERSION}.jar"
 
 # If you would like to enable the shell script to use


### PR DESCRIPTION
Add the ability to explicitly override the version of Hub-Detect used.

The main use-case for this is if a new release breaks things for a customer, they can override to the previous version, turning a customer-down panic into a regular issue. In addition, this allows applications like CoPilot to test new releases within their workflow before rolling it out to customers.

The build.gradle generation was updated (and tested with a non-snapshot version number). The src/main/resources instance of the scrip was generated via this method as well.

Script has been used in a test project as generated both with and without overrides to verify continued working functionality