### PR TITLE
Add type checking to Detect

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
@@ -22,8 +22,6 @@
  */
 package com.blackducksoftware.integration.hub.detect
 
-import java.nio.charset.StandardCharsets
-
 import javax.annotation.PostConstruct
 
 import org.slf4j.Logger
@@ -48,11 +46,11 @@ import com.blackducksoftware.integration.hub.detect.model.DetectProject
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.util.IntegrationEscapeUtil
-import com.blackducksoftware.integration.util.ResourceUtil
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
 @SpringBootApplication
+@groovy.transform.CompileStatic
 class Application {
     private final Logger logger = LoggerFactory.getLogger(Application.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
@@ -49,8 +49,10 @@ import com.blackducksoftware.integration.util.IntegrationEscapeUtil
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
+import groovy.transform.TypeChecked
+
+@TypeChecked
 @SpringBootApplication
-@groovy.transform.TypeChecked
 class Application {
     private final Logger logger = LoggerFactory.getLogger(Application.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
@@ -50,7 +50,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
 @SpringBootApplication
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class Application {
     private final Logger logger = LoggerFactory.getLogger(Application.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class BuildInfo {
     @SerializedName("detect")
     final String detectVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class BuildInfo {
     @SerializedName("detect")
     final String detectVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/BuildInfo.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class BuildInfo {
     @SerializedName("detect")
     final String detectVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -42,8 +42,10 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.util.ResourceUtil
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DetectConfiguration {
     private final Logger logger = LoggerFactory.getLogger(DetectProperties.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -43,6 +43,7 @@ import com.blackducksoftware.integration.util.ResourceUtil
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.CompileStatic
 class DetectConfiguration {
     private final Logger logger = LoggerFactory.getLogger(DetectProperties.class)
 
@@ -107,7 +108,7 @@ class DetectConfiguration {
         mutablePropertySources.each { propertySource ->
             if (propertySource instanceof EnumerablePropertySource) {
                 EnumerablePropertySource enumerablePropertySource = (EnumerablePropertySource) propertySource
-                enumerablePropertySource.propertyNames.each { propertyName ->
+                enumerablePropertySource.propertyNames.each { String propertyName ->
                     if (propertyName && propertyName.startsWith(DETECT_PROPERTY_PREFIX)) {
                         allDetectPropertyKeys.add(propertyName)
                     }
@@ -120,8 +121,8 @@ class DetectConfiguration {
         }
 
         if (detectProperties.hubSignatureScannerRelativePathsToExclude) {
-            detectProperties.hubSignatureScannerRelativePathsToExclude.each {
-                excludedScanPaths.add(new File(sourceDirectory, it).getCanonicalPath())
+            detectProperties.hubSignatureScannerRelativePathsToExclude.each { String path ->
+                excludedScanPaths.add(new File(sourceDirectory, path).getCanonicalPath())
             }
         }
     }
@@ -152,7 +153,7 @@ class DetectConfiguration {
     public void logConfiguration() {
         List<String> configurationPieces = []
         configurationPieces.add('')
-        configurationPieces.add("Detect Version: ${buildInfo.getDetectVersion()}")
+        configurationPieces.add("Detect Version: ${buildInfo.getDetectVersion()}" as String)
         configurationPieces.add('Current property values:')
         configurationPieces.add('-'.multiply(60))
         def propertyFields = DetectProperties.class.getDeclaredFields().findAll {
@@ -167,13 +168,13 @@ class DetectConfiguration {
             String fieldName = it.name
             Object fieldValue = it.get(detectProperties)
             if (it.type.isArray()) {
-                fieldValue = fieldValue.join(', ')
+                fieldValue = (fieldValue as String[]).join(', ')
             }
             if (fieldName && fieldValue && 'metaClass' != fieldName) {
                 if (fieldName.toLowerCase().contains('password')) {
-                    fieldValue = '*'.multiply(fieldValue.length())
+                    fieldValue = '*'.multiply((fieldValue as String).length())
                 }
-                configurationPieces.add("${fieldName} = ${fieldValue}")
+                configurationPieces.add("${fieldName} = ${fieldValue}" as String)
             }
             it.accessible = false
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -43,7 +43,7 @@ import com.blackducksoftware.integration.util.ResourceUtil
 import com.google.gson.Gson
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DetectConfiguration {
     private final Logger logger = LoggerFactory.getLogger(DetectProperties.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
@@ -50,6 +50,7 @@ import com.blackducksoftware.integration.util.ExcludedIncludedFilter
 import com.blackducksoftware.integration.util.IntegrationEscapeUtil
 import com.google.gson.Gson
 
+// No type checking to access read-only property
 @Component
 class DetectProjectManager {
     private final Logger logger = LoggerFactory.getLogger(DetectProjectManager.class)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.help.ValueDescription
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DetectProperties {
     private static final String GROUP_HUB_CONFIGURATION = 'hub configuration'
     private static final String GROUP_LOGGING = 'logging'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -27,8 +27,10 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.detect.help.ValueDescription
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DetectProperties {
     private static final String GROUP_HUB_CONFIGURATION = 'hub configuration'
     private static final String GROUP_LOGGING = 'logging'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.help.ValueDescription
 
 @Component
+@groovy.transform.CompileStatic
 class DetectProperties {
     private static final String GROUP_HUB_CONFIGURATION = 'hub configuration'
     private static final String GROUP_LOGGING = 'logging'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
@@ -20,7 +20,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.blackducksoftware.integration.hub.detect;
+package com.blackducksoftware.integration.hub.detect
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.ExternalId
@@ -31,9 +31,10 @@ import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
+@groovy.transform.CompileStatic
 class ExternalIdTypeAdapter extends TypeAdapter<ExternalId> {
-    def forgeMap = [cocoapods: Forge.COCOAPODS, maven: Forge.MAVEN, npm: Forge.NPM, pypi: Forge.PYPI, rubygems: Forge.RUBYGEMS]
-    def gson = new Gson()
+    Map<String, Forge> forgeMap = [cocoapods: Forge.COCOAPODS, maven: Forge.MAVEN, npm: Forge.NPM, pypi: Forge.PYPI, rubygems: Forge.RUBYGEMS]
+    Gson gson = new Gson()
 
     @Override
     void write(final JsonWriter jsonWriter, final ExternalId value) throws IOException {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
@@ -31,7 +31,7 @@ import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class ExternalIdTypeAdapter extends TypeAdapter<ExternalId> {
     Map<String, Forge> forgeMap = [cocoapods: Forge.COCOAPODS, maven: Forge.MAVEN, npm: Forge.NPM, pypi: Forge.PYPI, rubygems: Forge.RUBYGEMS]
     Gson gson = new Gson()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/ExternalIdTypeAdapter.groovy
@@ -31,7 +31,9 @@ import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class ExternalIdTypeAdapter extends TypeAdapter<ExternalId> {
     Map<String, Forge> forgeMap = [cocoapods: Forge.COCOAPODS, maven: Forge.MAVEN, npm: Forge.NPM, pypi: Forge.PYPI, rubygems: Forge.RUBYGEMS]
     Gson gson = new Gson()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
@@ -33,7 +33,9 @@ import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 abstract class BomTool {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
@@ -33,6 +33,7 @@ import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
+@groovy.transform.CompileStatic
 abstract class BomTool {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/BomTool.groovy
@@ -33,7 +33,7 @@ import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 abstract class BomTool {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.cocoapods.CocoapodsP
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CocoapodsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CocoapodsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
@@ -34,7 +34,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.PathEx
 import com.blackducksoftware.integration.hub.detect.bomtool.cocoapods.CocoapodsPackager
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
+
 @Component
+@groovy.transform.CompileStatic
 class CocoapodsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CocoapodsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CocoapodsBomTool.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CocoapodsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CocoapodsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
@@ -39,6 +39,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
+@groovy.transform.CompileStatic
 class CondaBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CondaBomTool.class)
 
@@ -69,7 +70,7 @@ class CondaBomTool extends BomTool {
     public List<DetectCodeLocation> extractDetectCodeLocations() {
         List<String> condaListOptions = ['list']
         if (detectConfiguration.getCondaEnvironmentName()) {
-            condaListOptions.add([
+            condaListOptions.addAll([
                 '-n',
                 detectConfiguration.getCondaEnvironmentName()
             ])

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
@@ -39,7 +39,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CondaBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CondaBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
@@ -38,8 +38,10 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CondaBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CondaBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
@@ -37,10 +37,10 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
-import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
 
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CpanBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CpanBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
@@ -40,7 +40,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOu
 import groovy.transform.CompileStatic
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CpanBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CpanBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
@@ -37,7 +37,10 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.transform.CompileStatic
+
 @Component
+@groovy.transform.CompileStatic
 class CpanBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(CpanBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.cran.PackratPackager
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CranBomTool extends BomTool {
     public static final Forge CRAN = new Forge('cran', '/')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class CranBomTool extends BomTool {
     public static final Forge CRAN = new Forge('cran', '/')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CranBomTool.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CranBomTool extends BomTool {
     public static final Forge CRAN = new Forge('cran', '/')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
+@groovy.transform.CompileStatic
 class DockerBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(DockerBomTool.class)
 
@@ -116,7 +117,7 @@ class DockerBomTool extends BomTool {
 
         List<String> bashArguments = [
             "-c",
-            "${shellScriptFile.absolutePath} --spring.config.location=\"${dockerPropertiesDirectory.getAbsolutePath()}\" ${imageArgument}"
+            "${shellScriptFile.absolutePath} --spring.config.location=\"${dockerPropertiesDirectory.getAbsolutePath()}\" ${imageArgument}" as String
         ]
 
         Executable dockerExecutable = new Executable(shellScriptFile.parentFile, environmentVariables, bashExecutablePath, bashArguments)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DockerBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(DockerBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DockerBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(DockerBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
@@ -39,7 +39,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GoDepBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoDepBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
@@ -38,8 +38,10 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class GoDepBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoDepBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
@@ -39,6 +39,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
+@groovy.transform.CompileStatic
 class GoDepBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoDepBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.google.gson.Gson
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GoGodepsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoGodepsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.CompileStatic
 class GoGodepsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoGodepsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoGodepsBomTool.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class GoGodepsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoGodepsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
@@ -34,7 +34,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GoVndrBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoVndrBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
@@ -34,6 +34,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class GoVndrBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoVndrBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoVndrBomTool.groovy
@@ -33,8 +33,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.go.vndr.VndrParser
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class GoVndrBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GoVndrBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.CompileStatic
 class GradleBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GradleBomTool.class)
 
@@ -72,7 +73,7 @@ class GradleBomTool extends BomTool {
 
         File[] additionalTargets = detectFileManager.findFilesToDepth(detectConfiguration.sourceDirectory, 'build', detectConfiguration.searchDepth)
         if (additionalTargets) {
-            additionalTargets.each { hubSignatureScanner.registerPathToScan(it) }
+            additionalTargets.each { File file -> hubSignatureScanner.registerPathToScan(file) }
         }
         codeLocations
     }
@@ -107,7 +108,7 @@ class GradleBomTool extends BomTool {
         logger.info("using ${initScriptPath} as the path for the gradle init script")
         Executable executable = new Executable(sourceDirectory, gradleExecutable, [
             detectConfiguration.getGradleBuildCommand(),
-            "--init-script=${initScriptPath}"
+            "--init-script=${initScriptPath}" as String
         ])
         executableRunner.execute(executable)
 
@@ -115,9 +116,9 @@ class GradleBomTool extends BomTool {
         File blackduckDirectory = new File(buildDirectory, 'blackduck')
 
         File[] codeLocationFiles = detectFileManager.findFiles(blackduckDirectory, '*_detectCodeLocation.json')
-        List<DetectCodeLocation> codeLocations = codeLocationFiles.collect {
-            logger.debug("Code Location file name: ${it.getName()}")
-            String codeLocationJson = it.getText(StandardCharsets.UTF_8.name())
+        List<DetectCodeLocation> codeLocations = codeLocationFiles.collect { File codeLocationFile ->
+            logger.debug("Code Location file name: ${codeLocationFile.getName()}")
+            String codeLocationJson = codeLocationFile.getText(StandardCharsets.UTF_8.name())
             gson.fromJson(codeLocationJson, DetectCodeLocation.class)
         }
         if (detectConfiguration.gradleCleanupBuildBlackduckDirectory) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.google.gson.Gson
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GradleBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GradleBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class GradleBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(GradleBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
+@groovy.transform.CompileStatic
 class MavenBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(MavenBomTool.class)
 
@@ -72,7 +73,7 @@ class MavenBomTool extends BomTool {
     List<DetectCodeLocation> extractDetectCodeLocations() {
         def arguments = ["dependency:tree"]
         if (detectConfiguration.getMavenScope()?.trim()) {
-            arguments.add("-Dscope=${detectConfiguration.getMavenScope()}")
+            arguments.add("-Dscope=${detectConfiguration.getMavenScope()}" as String)
         }
         final Executable mvnExecutable = new Executable(detectConfiguration.sourceDirectory, mvnExecutable, arguments)
         final ExecutableOutput mvnOutput = executableRunner.execute(mvnExecutable)
@@ -81,7 +82,7 @@ class MavenBomTool extends BomTool {
 
         File[] additionalTargets = detectFileManager.findFilesToDepth(detectConfiguration.sourceDirectory, 'target', detectConfiguration.searchDepth)
         if (additionalTargets) {
-            additionalTargets.each { hubSignatureScanner.registerPathToScan(it) }
+            additionalTargets.each { File target -> hubSignatureScanner.registerPathToScan(target) }
         }
 
         codeLocations

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class MavenBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(MavenBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class MavenBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(MavenBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
@@ -34,7 +34,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NpmBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NpmBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
@@ -33,8 +33,10 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class NpmBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NpmBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
@@ -34,6 +34,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
 @Component
+@groovy.transform.CompileStatic
 class NpmBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NpmBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class NugetBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NugetBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NugetBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
 @Component
+@groovy.transform.CompileStatic
 class NugetBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(NugetBomTool.class)
 
@@ -77,16 +78,16 @@ class NugetBomTool extends BomTool {
             return []
         }
 
-        def options =  [
-            "--target_path=${sourcePath}",
-            "--output_directory=${outputDirectory.getAbsolutePath()}",
-            "--ignore_failure=${detectConfiguration.getNugetInspectorIgnoreFailure()}"
+        List<String> options =  [
+            "--target_path=${sourcePath}" as String,
+            "--output_directory=${outputDirectory.getAbsolutePath()}" as String,
+            "--ignore_failure=${detectConfiguration.getNugetInspectorIgnoreFailure()}" as String
         ]
         if (detectConfiguration.getNugetInspectorExcludedModules()) {
-            options.add("--excluded_modules=${detectConfiguration.getNugetInspectorExcludedModules()}")
+            options.add("--excluded_modules=${detectConfiguration.getNugetInspectorExcludedModules()}" as String)
         }
         if (detectConfiguration.getNugetPackagesRepoUrl()) {
-            options.add("--packages_repo_url=${detectConfiguration.getNugetPackagesRepoUrl()}")
+            options.add("--packages_repo_url=${detectConfiguration.getNugetPackagesRepoUrl()}" as String)
         }
         if (logger.traceEnabled) {
             options.add('-v')

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
@@ -35,7 +35,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PackagistBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PackagistBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
@@ -35,6 +35,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class PackagistBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PackagistBomTool.class)
 
@@ -61,8 +62,8 @@ class PackagistBomTool extends BomTool {
     }
 
     List<DetectCodeLocation> extractDetectCodeLocations() {
-        String composerJsonText = new File(sourcePath, 'composer.json').getText(StandardCharsets.UTF_8)
-        String composerLockText = new File(sourcePath, 'composer.lock').getText(StandardCharsets.UTF_8)
+        String composerJsonText = new File(sourcePath, 'composer.json').getText(StandardCharsets.UTF_8.toString())
+        String composerLockText = new File(sourcePath, 'composer.lock').getText(StandardCharsets.UTF_8.toString())
 
         DependencyNode rootDependencyNode = packagistParser.getDependencyNodeFromProject(composerJsonText, composerLockText)
         def detectCodeLocation = new DetectCodeLocation(getBomToolType(), sourcePath, rootDependencyNode)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PackagistBomTool.groovy
@@ -34,8 +34,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.packagist.PackagistP
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PackagistBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PackagistBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
@@ -36,7 +36,10 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.util.slurpersupport.GPathResult
+
 @Component
+//@groovy.transform.CompileStatic
 class PearBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PearBomTool.class)
 
@@ -74,9 +77,9 @@ class PearBomTool extends BomTool {
         ExecutableOutput pearDependencies = executableRunner.runExe(pearExePath, 'package-dependencies', PACKAGE_XML_FILENAME)
 
         File packageFile = detectFileManager.findFile(sourcePath, PACKAGE_XML_FILENAME)
-        def packageXml = new XmlSlurper().parseText(packageFile.text)
+        GPathResult packageXml = new XmlSlurper().parseText(packageFile.text)
         String rootName = packageXml.name
-        String rootVersion = packageXml.version.release
+        String rootVersion = packageXml.version.result
 
         Set<DependencyNode> childDependencyNodes = pearDependencyFinder.parsePearDependencyList(pearListing, pearDependencies)
         def detectCodeLocation = new DetectCodeLocation(

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 
+import groovy.transform.TypeChecked
 import groovy.util.slurpersupport.GPathResult
 
 @Component
@@ -57,6 +58,7 @@ class PearBomTool extends BomTool {
     }
 
     @Override
+    @TypeChecked
     public boolean isBomToolApplicable() {
         boolean containsPackageXml = detectFileManager.containsAllFiles(sourcePath, PACKAGE_XML_FILENAME)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
@@ -39,7 +39,6 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOu
 import groovy.util.slurpersupport.GPathResult
 
 @Component
-//@groovy.transform.TypeChecked
 class PearBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PearBomTool.class)
 
@@ -79,7 +78,7 @@ class PearBomTool extends BomTool {
         File packageFile = detectFileManager.findFile(sourcePath, PACKAGE_XML_FILENAME)
         GPathResult packageXml = new XmlSlurper().parseText(packageFile.text)
         String rootName = packageXml.name
-        String rootVersion = packageXml.version.result
+        String rootVersion = packageXml.version.release
 
         Set<DependencyNode> childDependencyNodes = pearDependencyFinder.parsePearDependencyList(pearListing, pearDependencies)
         def detectCodeLocation = new DetectCodeLocation(

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
@@ -39,7 +39,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOu
 import groovy.util.slurpersupport.GPathResult
 
 @Component
-//@groovy.transform.CompileStatic
+//@groovy.transform.TypeChecked
 class PearBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PearBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
@@ -37,8 +37,10 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PipBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PipBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
@@ -38,7 +38,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PipBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PipBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
@@ -38,6 +38,7 @@ import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.util.executable.Executable
 
 @Component
+@groovy.transform.CompileStatic
 class PipBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(PipBomTool.class)
 
@@ -100,7 +101,7 @@ class PipBomTool extends BomTool {
         // Install requirements file and add it as an option for the inspector
         if (detectConfiguration.requirementsFilePath) {
             def requirementsFile = new File(detectConfiguration.requirementsFilePath)
-            pipInspectorOptions.add("--requirements=${requirementsFile.absolutePath}")
+            pipInspectorOptions.add("--requirements=${requirementsFile.absolutePath}" as String)
         }
 
         // Install project if it can find one and pass its name to the inspector
@@ -114,7 +115,7 @@ class PipBomTool extends BomTool {
                 String[] output = executableRunner.execute(findProjectNameExecutable).standardOutput.split(System.lineSeparator())
                 projectName = output[output.length - 1].trim()
             }
-            pipInspectorOptions.add("--projectname=${projectName}")
+            pipInspectorOptions.add("--projectname=${projectName}" as String)
         }
 
         def pipInspector = new Executable(sourceDirectory, pythonPath, pipInspectorOptions)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
@@ -38,7 +38,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class RubygemsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(RubygemsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
@@ -37,8 +37,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.rubygems.RubygemsNod
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class RubygemsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(RubygemsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/RubygemsBomTool.groovy
@@ -38,6 +38,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class RubygemsBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(RubygemsBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
@@ -38,7 +38,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SbtBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(SbtBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
@@ -37,8 +37,10 @@ import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class SbtBomTool extends BomTool {
     private final Logger logger = LoggerFactory.getLogger(SbtBomTool.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.yarn.YarnPackager
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class YarnBomTool extends BomTool {
     @Autowired
     YarnPackager yarnPackager

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class YarnBomTool extends BomTool {
     @Autowired
     YarnPackager yarnPackager

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/YarnBomTool.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class YarnBomTool extends BomTool {
     @Autowired
     YarnPackager yarnPackager

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.metadata.Subcomp
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CocoapodsPackager {
     final List<String> fuzzyVersionIdentifiers = ['>', '<', '~>', '=']
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.nameversion.builder.Subcompo
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.SubcomponentMetadata
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CocoapodsPackager {
     final List<String> fuzzyVersionIdentifiers = ['>', '<', '~>', '=']
 
@@ -70,7 +72,7 @@ class CocoapodsPackager {
             }
         }
 
-        builder.build().children.collect { nameVersionNodeTransformer.createDependencyNode(Forge.COCOAPODS, it) } as Set
+        builder.build().children.collect { nameVersionNodeTransformer.createDependencyNode(Forge.COCOAPODS, it as NameVersionNode) } as Set
     }
 
     private NameVersionNode buildNameVersionNode(SubcomponentNodeBuilder builder, Pod pod) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/CocoapodsPackager.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.metadata.Subcomp
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 
 @Component
+@groovy.transform.CompileStatic
 class CocoapodsPackager {
     final List<String> fuzzyVersionIdentifiers = ['>', '<', '~>', '=']
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
 
+@groovy.transform.CompileStatic
 @ToString(includePackage=false, includeFields=true)
 class ExternalSources {
     List<PodSource> sources = []

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
@@ -25,8 +25,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.cocoapods
 import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
+import groovy.transform.TypeChecked
 
-@groovy.transform.TypeChecked
+@TypeChecked
 @ToString(includePackage=false, includeFields=true)
 class ExternalSources {
     List<PodSource> sources = []

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/ExternalSources.groovy
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 @ToString(includePackage=false, includeFields=true)
 class ExternalSources {
     List<PodSource> sources = []

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
 
+@groovy.transform.CompileStatic
 @ToString(includePackage=false, includeFields=true)
 class Pod {
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
@@ -25,8 +25,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.cocoapods
 import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
+import groovy.transform.TypeChecked
 
-@groovy.transform.TypeChecked
+@TypeChecked
 @ToString(includePackage=false, includeFields=true)
 class Pod {
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/Pod.groovy
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 
 import groovy.transform.ToString
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 @ToString(includePackage=false, includeFields=true)
 class Pod {
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
@@ -27,8 +27,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 import groovy.transform.ToString
+import groovy.transform.TypeChecked
 
-@groovy.transform.TypeChecked
+@TypeChecked
 @ToString(includePackage=false, includeFields=true, ignoreNulls=true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodSource {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 import groovy.transform.ToString
 
+@groovy.transform.CompileStatic
 @ToString(includePackage=false, includeFields=true, ignoreNulls=true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodSource {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodSource.groovy
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 import groovy.transform.ToString
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 @ToString(includePackage=false, includeFields=true, ignoreNulls=true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodSource {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.cocoapods
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@groovy.transform.CompileStatic
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodfileLock {
     @JsonProperty('PODS')

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
@@ -25,7 +25,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.cocoapods
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodfileLock {
     @JsonProperty('PODS')

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cocoapods/PodfileLock.groovy
@@ -25,7 +25,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.cocoapods
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 @JsonIgnoreProperties(ignoreUnknown = true)
 class PodfileLock {
     @JsonProperty('PODS')

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class CondaInfo {
     @SerializedName("platform")
     String platform

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CondaInfo {
     @SerializedName("platform")
     String platform

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaInfo.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class CondaInfo {
     @SerializedName("platform")
     String platform

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class CondaListElement {
     @SerializedName("name")
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CondaListElement {
     @SerializedName("name")
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListElement.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.conda
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class CondaListElement {
     @SerializedName("name")
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
@@ -35,17 +35,18 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 @Component
+@groovy.transform.CompileStatic
 class CondaListParser {
     @Autowired
     Gson gson
 
     Set<DependencyNode> parse(String listJsonText, String infoJsonText) {
         final Type listType = new TypeToken<ArrayList<CondaListElement>>() {}.getType()
-        final List<CondaListElement> condaList = gson.fromJson(listJsonText, listType)
+        final List<CondaListElement> condaList = gson.fromJson(listJsonText, listType) as List<CondaListElement>
         final CondaInfo condaInfo = gson.fromJson(infoJsonText, CondaInfo.class)
         final String platform = condaInfo.platform
 
-        condaList.collect { condaListElementToDependencyNodeTransformer(platform, it) }
+        condaList.collect { condaListElementToDependencyNodeTransformer(platform, it) } as Set
     }
 
     DependencyNode condaListElementToDependencyNodeTransformer(String platform, CondaListElement element) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
@@ -34,8 +34,10 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CondaListParser {
     @Autowired
     Gson gson

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/conda/CondaListParser.groovy
@@ -35,7 +35,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CondaListParser {
     @Autowired
     Gson gson

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
@@ -29,8 +29,10 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CpanListParser {
     private final Logger logger = LoggerFactory.getLogger(CpanListParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
@@ -30,7 +30,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CpanListParser {
     private final Logger logger = LoggerFactory.getLogger(CpanListParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
@@ -30,6 +30,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 
 @Component
+@groovy.transform.CompileStatic
 class CpanListParser {
     private final Logger logger = LoggerFactory.getLogger(CpanListParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
@@ -33,7 +33,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class CpanPackager {
     private final Logger logger = LoggerFactory.getLogger(CpanPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
@@ -32,8 +32,10 @@ import com.blackducksoftware.integration.hub.detect.bomtool.CpanBomTool
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class CpanPackager {
     private final Logger logger = LoggerFactory.getLogger(CpanPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
@@ -33,6 +33,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
 @Component
+@groovy.transform.CompileStatic
 class CpanPackager {
     private final Logger logger = LoggerFactory.getLogger(CpanPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
@@ -32,7 +32,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeI
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class PackRatNodeParser {
     private final Logger logger = LoggerFactory.getLogger(PackRatNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
@@ -26,13 +26,13 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.bomtool.CranBomTool
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
+@groovy.transform.CompileStatic
 public class PackRatNodeParser {
     private final Logger logger = LoggerFactory.getLogger(PackRatNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
@@ -32,7 +32,9 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeI
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class PackRatNodeParser {
     private final Logger logger = LoggerFactory.getLogger(PackRatNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
@@ -27,8 +27,10 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 public class PackratPackager {
     @Autowired
     private final NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
@@ -25,11 +25,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
-
 @Component
+@groovy.transform.CompileStatic
 public class PackratPackager {
     @Autowired
     private final NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
@@ -28,7 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class PackratPackager {
     @Autowired
     private final NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
@@ -27,8 +27,10 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DockerProperties {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DockerProperties {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
 @Component
+@groovy.transform.CompileStatic
 class DockerProperties {
     @Autowired
     DetectConfiguration detectConfiguration

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.google.gson.Gson
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DepPackager {
     private final Logger logger = LoggerFactory.getLogger(DepPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunnerException
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DepPackager {
     private final Logger logger = LoggerFactory.getLogger(DepPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/DepPackager.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.CompileStatic
 class DepPackager {
     private final Logger logger = LoggerFactory.getLogger(DepPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GopkgLock {
     // see https://github.com/golang/dep/blob/master/lock.go for the source of the lock file
     List<Project> projects

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class GopkgLock {
     // see https://github.com/golang/dep/blob/master/lock.go for the source of the lock file
     List<Project> projects

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLock.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GopkgLock {
     // see https://github.com/golang/dep/blob/master/lock.go for the source of the lock file
     List<Project> projects

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
@@ -28,8 +28,8 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.moandjiezana.toml.Toml
 
+@groovy.transform.CompileStatic
 class GopkgLockParser {
-
     public List<DependencyNode> parseDepLock(String depLockContents) {
         List<DependencyNode> nodes = new ArrayList<>()
         GopkgLock gopkgLock = new Toml().read(depLockContents).to(GopkgLock.class)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
@@ -28,7 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.moandjiezana.toml.Toml
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GopkgLockParser {
     public List<DependencyNode> parseDepLock(String depLockContents) {
         List<DependencyNode> nodes = new ArrayList<>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/GopkgLockParser.groovy
@@ -28,7 +28,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.moandjiezana.toml.Toml
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GopkgLockParser {
     public List<DependencyNode> parseDepLock(String depLockContents) {
         List<DependencyNode> nodes = new ArrayList<>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.go
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class Project {
     String name
     String branch

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.go
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class Project {
     String name
     String branch

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/Project.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.go
 
+@groovy.transform.CompileStatic
 class Project {
     String name
     String branch

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SolveMeta {
     @SerializedName("inputs-digest")
     String inputsDigest

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class SolveMeta {
     @SerializedName("inputs-digest")
     String inputsDigest

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/SolveMeta.groovy
@@ -20,8 +20,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package com.blackducksoftware.integration.hub.detect.bomtool.go
+
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class SolveMeta {
     @SerializedName("inputs-digest")
     String inputsDigest

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
@@ -28,7 +28,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.google.gson.Gson
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GoGodepsParser {
     private final Gson gson
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
@@ -28,20 +28,21 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.google.gson.Gson
 
+@groovy.transform.CompileStatic
 class GoGodepsParser {
     private final Gson gson
 
     public GoGodepsParser(Gson gson) {
-        this.gson = gson;
+        this.gson = gson
     }
 
     public List<DependencyNode> extractProjectDependencies(String goDepContents) {
         GodepsFile goDepsFile = gson.fromJson(goDepContents, GodepsFile.class)
         List<DependencyNode> children = []
-        goDepsFile.deps.each {
+        goDepsFile.deps.each { GodepDependency dep ->
             def version = ''
-            if (it.comment?.trim()) {
-                version = it.comment.trim()
+            if (dep.comment?.trim()) {
+                version = dep.comment.trim()
                 //TODO test with kubernetes
                 if (version.matches('.*-.*-.*')) {
                     //v1.6-27-23859436879234678  should be changed to v1.6
@@ -49,10 +50,10 @@ class GoGodepsParser {
                     version = version.substring(0, version.lastIndexOf('-'))
                 }
             } else {
-                version = it.rev.trim()
+                version = dep.rev.trim()
             }
-            final ExternalId dependencyExternalId = new NameVersionExternalId(GoDepBomTool.GOLANG, it.importPath, version)
-            final DependencyNode dependency = new DependencyNode(it.importPath, version, dependencyExternalId)
+            final ExternalId dependencyExternalId = new NameVersionExternalId(GoDepBomTool.GOLANG, dep.importPath, version)
+            final DependencyNode dependency = new DependencyNode(dep.importPath, version, dependencyExternalId)
             children.add(dependency)
         }
         children

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GoGodepsParser.groovy
@@ -28,7 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 import com.google.gson.Gson
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GoGodepsParser {
     private final Gson gson
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GodepDependency {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class GodepDependency {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepDependency.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GodepDependency {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class GodepsFile {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GodepsFile {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/godep/GodepsFile.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.go.godep
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GodepsFile {
     @SerializedName("ImportPath")
     String importPath

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
@@ -27,7 +27,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.Extern
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class VndrParser {
     public List<DependencyNode> parseVendorConf(String vendorConfContents) {
         List<DependencyNode> nodes = new ArrayList<>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
@@ -27,13 +27,14 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.Extern
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 
+@groovy.transform.CompileStatic
 class VndrParser {
     public List<DependencyNode> parseVendorConf(String vendorConfContents) {
         List<DependencyNode> nodes = new ArrayList<>()
         String contents = vendorConfContents.trim()
         def lines = contents.split(System.lineSeparator())
         //TODO test against moby
-        lines.each { line ->
+        lines.each { String line ->
             if (line?.trim() && !line.startsWith('#')) {
                 def parts = line.split(' ')
                 final ExternalId dependencyExternalId = new NameVersionExternalId(GoDepBomTool.GOLANG, parts[0], parts[1])

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
@@ -27,7 +27,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.Extern
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.GoDepBomTool
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class VndrParser {
     public List<DependencyNode> parseVendorConf(String vendorConfContents) {
         List<DependencyNode> nodes = new ArrayList<>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
@@ -33,8 +33,10 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenE
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class MavenCodeLocationPackager {
     public static final Pattern gavRegex = Pattern.compile('(.*?):(.*?):(.*?):([^:\\n\\r]*)(:(.*))*')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
@@ -34,7 +34,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class MavenCodeLocationPackager {
     public static final Pattern gavRegex = Pattern.compile('(.*?):(.*?):(.*?):([^:\\n\\r]*)(:(.*))*')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
@@ -30,11 +30,11 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.ExternalId
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenExternalId
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
 @Component
+@groovy.transform.CompileStatic
 class MavenCodeLocationPackager {
     public static final Pattern gavRegex = Pattern.compile('(.*?):(.*?):(.*?):([^:\\n\\r]*)(:(.*))*')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
@@ -41,7 +41,10 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
+import groovy.transform.TypeChecked
+
 @Component
+@TypeChecked
 class NpmCliDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(NpmCliDependencyFinder.class)
     private static final String JSON_NAME = 'name'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
@@ -42,7 +42,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
 @Component
-@groovy.transform.CompileStatic
+
 class NpmCliDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(NpmCliDependencyFinder.class)
     private static final String JSON_NAME = 'name'
@@ -92,10 +92,10 @@ class NpmCliDependencyFinder {
     private void populateChildren(DependencyNode parentDependencyNode, JsonObject parentNodeChildren) {
         Set<Entry<String, JsonElement>> elements = parentNodeChildren?.entrySet()
         elements?.each { Entry<String, JsonElement> it ->
-            JsonElement element = it.value as JsonElement
+            JsonObject element = it.value as JsonObject
             String name = it.key
-            String version = element.getAsJsonPrimitive()?.getAsString()
-            JsonObject children = element.getAsJsonObject()
+            String version = element.getAsJsonPrimitive(JSON_VERSION)?.getAsString()
+            JsonObject children = element.getAsJsonObject(JSON_DEPENDENCIES)
 
             def externalId = new NameVersionExternalId(Forge.NPM, name, version)
             def newNode = new DependencyNode(name, version, externalId)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
@@ -42,7 +42,6 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
 @Component
-
 class NpmCliDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(NpmCliDependencyFinder.class)
     private static final String JSON_NAME = 'name'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
@@ -28,19 +28,20 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageId
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageSet
 
+@groovy.transform.CompileStatic
 public class NugetDependencyNodeBuilder {
 
-    final List<NugetPackageSet> packageSets = new ArrayList<NugetPackageSet>();
-    final Map<NugetPackageId, DependencyNode> nodeMap = new HashMap<>();
+    final List<NugetPackageSet> packageSets = new ArrayList<NugetPackageSet>()
+    final Map<NugetPackageId, DependencyNode> nodeMap = new HashMap<>()
 
     public NugetDependencyNodeBuilder() {
     }
 
     public void addPackageSets(List<NugetPackageSet> sets) {
-        packageSets.addAll(sets);
+        packageSets.addAll(sets)
     }
     public void addPackageSet(NugetPackageSet set) {
-        packageSets.add(set);
+        packageSets.add(set)
     }
 
     public Set<DependencyNode> createDependencyNodes(List<NugetPackageId> packageDependencies) {
@@ -53,11 +54,11 @@ public class NugetDependencyNodeBuilder {
 
 
     public DependencyNode getOrCreateDependencyNode(NugetPackageId id) {
-        def node = nodeMap.getOrDefault(id, null)
+        def node = nodeMap.get(id, null)
         if (node == null) {
             def externalId = new NameVersionExternalId(Forge.NUGET, id.name, id.version)
             node = new DependencyNode(id.name, id.version, externalId)
-            nodeMap.put(id, node);
+            nodeMap.put(id, node)
 
             //restore children
             def packageSet = packageSets.find{ set ->

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
@@ -28,7 +28,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageId
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageSet
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class NugetDependencyNodeBuilder {
 
     final List<NugetPackageSet> packageSets = new ArrayList<NugetPackageSet>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetDependencyNodeBuilder.groovy
@@ -28,7 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVe
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageId
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetPackageSet
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class NugetDependencyNodeBuilder {
 
     final List<NugetPackageSet> packageSets = new ArrayList<NugetPackageSet>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
@@ -43,8 +43,10 @@ import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class NugetInspectorPackager {
     private final Logger logger = LoggerFactory.getLogger(NugetInspectorPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
@@ -44,6 +44,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.CompileStatic
 class NugetInspectorPackager {
     private final Logger logger = LoggerFactory.getLogger(NugetInspectorPackager.class)
 
@@ -66,10 +67,10 @@ class NugetInspectorPackager {
     NameVersionNodeTransformer nameVersionNodeTransformer
 
     public List<DetectCodeLocation> createDetectCodeLocation(File dependencyNodeFile) {
-        String text = dependencyNodeFile.getText(StandardCharsets.UTF_8.name());
+        String text = dependencyNodeFile.getText(StandardCharsets.UTF_8.name())
         NugetInspection nugetInspection = gson.fromJson(text, NugetInspection.class)
 
-        def codeLocations = new ArrayList<DetectCodeLocation>();
+        def codeLocations = new ArrayList<DetectCodeLocation>()
         nugetInspection.containers.each {
             registerScanPaths(it)
             codeLocations.addAll(createDetectCodeLocationFromNugetContainer(it))

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
@@ -44,7 +44,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.google.gson.Gson
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetInspectorPackager {
     private final Logger logger = LoggerFactory.getLogger(NugetInspectorPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
@@ -27,7 +27,9 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class NugetContainer {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class NugetContainer {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainer.groovy
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetContainer {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.nuget.model
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public enum NugetContainerType {
     @SerializedName("Solution")
     SOLUTION,

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
@@ -24,9 +24,10 @@ package com.blackducksoftware.integration.hub.detect.bomtool.nuget.model
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 public enum NugetContainerType {
     @SerializedName("Solution")
     SOLUTION,
     @SerializedName("Project")
-    PROJECT;
+    PROJECT
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetContainerType.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.nuget.model
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public enum NugetContainerType {
     @SerializedName("Solution")
     SOLUTION,

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class NugetInspection {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
@@ -27,7 +27,9 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class NugetInspection {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetInspection.groovy
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetInspection {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
@@ -27,7 +27,9 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class NugetPackageId {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetPackageId {
     @SerializedName('Name')
     String name

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageId.groovy
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class NugetPackageId {
     @SerializedName('Name')
     String name
@@ -36,37 +37,37 @@ class NugetPackageId {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.toLowerCase().hashCode());
-        result = prime * result + ((version == null) ? 0 : version.toLowerCase().hashCode());
-        return result;
+        final int prime = 31
+        int result = 1
+        result = prime * result + ((name == null) ? 0 : name.toLowerCase().hashCode())
+        result = prime * result + ((version == null) ? 0 : version.toLowerCase().hashCode())
+        return result
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
-            return false;
+            return false
         }
         if (!(obj instanceof NugetPackageId)) {
-            return false;
+            return false
         }
-        NugetPackageId other = (NugetPackageId) obj;
+        NugetPackageId other = (NugetPackageId) obj
         if (name == null) {
             if (other.name != null) {
-                return false;
+                return false
             }
         } else if (!name.equalsIgnoreCase(other.name)) {
-            return false;
+            return false
         }
         if (version == null) {
             if (other.version != null) {
-                return false;
+                return false
             }
         } else if (!version.equalsIgnoreCase(other.version)) {
-            return false;
+            return false
         }
-        return true;
+        return true
     }
 
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
@@ -27,7 +27,9 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class NugetPackageSet {
     @SerializedName('PackageId')
     NugetPackageId packageId

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NugetPackageSet {
     @SerializedName('PackageId')
     NugetPackageId packageId

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/model/NugetPackageSet.groovy
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
 import com.google.gson.annotations.SerializedName
 
+@groovy.transform.CompileStatic
 class NugetPackageSet {
     @SerializedName('PackageId')
     NugetPackageId packageId

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
@@ -33,8 +33,10 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PackagistParser {
     private Forge packagistForge = new Forge('packagist', ':')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
@@ -34,7 +34,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PackagistParser {
     private Forge packagistForge = new Forge('packagist', ':')
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
@@ -34,6 +34,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
 @Component
+@groovy.transform.CompileStatic
 class PackagistParser {
     private Forge packagistForge = new Forge('packagist', ':')
 
@@ -41,13 +42,13 @@ class PackagistParser {
     DetectConfiguration detectConfiguration
 
     public DependencyNode getDependencyNodeFromProject(String composerJsonText, String composerLockText) {
-        JsonObject composerJsonObject = new JsonParser().parse(composerJsonText)
+        JsonObject composerJsonObject = new JsonParser().parse(composerJsonText) as JsonObject
         String projectName = composerJsonObject.get('name')?.getAsString()
         String projectVersion = composerJsonObject.get('version')?.getAsString()
 
         def rootDependencyNode = new DependencyNode(projectName, projectVersion, new NameVersionExternalId(packagistForge, projectName, projectVersion))
 
-        JsonObject composerLockObject = new JsonParser().parse(composerLockText)
+        JsonObject composerLockObject = new JsonParser().parse(composerLockText) as JsonObject
         JsonArray packagistPackages = composerLockObject.get('packages')?.getAsJsonArray()
         List<String> startingPackages = getStartingPackages(composerJsonObject, false)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
@@ -30,7 +30,6 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.bomtool.PearBomTool
 import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
@@ -38,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOu
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
 @Component
+@groovy.transform.CompileStatic
 class PearDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(PearDependencyFinder.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOutput
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PearDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(PearDependencyFinder.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
@@ -37,7 +37,7 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableOu
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PearDependencyFinder {
     private final Logger logger = LoggerFactory.getLogger(PearDependencyFinder.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
@@ -34,8 +34,10 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeI
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PipInspectorTreeParser {
     final Logger logger = LoggerFactory.getLogger(PipInspectorTreeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
@@ -28,13 +28,14 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
+import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeBuilder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
 @Component
+@groovy.transform.CompileStatic
 class PipInspectorTreeParser {
     final Logger logger = LoggerFactory.getLogger(PipInspectorTreeParser.class)
 
@@ -48,7 +49,7 @@ class PipInspectorTreeParser {
     DependencyNode parse(NameVersionNodeTransformer nameVersionNodeTransformer, String treeText) {
         def lines = treeText.trim().split(System.lineSeparator()).toList()
 
-        def nodeBuilder = null
+        NameVersionNodeBuilder nodeBuilder = null
         Stack<NameVersionNode> tree = new Stack<>()
 
         int indentation = 0

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
@@ -35,7 +35,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeT
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PipInspectorTreeParser {
     final Logger logger = LoggerFactory.getLogger(PipInspectorTreeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.pip
 
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
+@groovy.transform.CompileStatic
 class PythonEnvironment {
     ExecutableType pythonType
     ExecutableType pipType

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.pip
 
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class PythonEnvironment {
     ExecutableType pythonType
     ExecutableType pipType

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironment.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.pip
 
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PythonEnvironment {
     ExecutableType pythonType
     ExecutableType pipType

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
@@ -32,8 +32,10 @@ import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PythonEnvironmentHandler {
     private final Logger logger = LoggerFactory.getLogger(PythonEnvironmentHandler.class)
     private final String VIRTUAL_ENV_NAME = 'venv'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
@@ -33,7 +33,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PythonEnvironmentHandler {
     private final Logger logger = LoggerFactory.getLogger(PythonEnvironmentHandler.class)
     private final String VIRTUAL_ENV_NAME = 'venv'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PythonEnvironmentHandler.groovy
@@ -33,6 +33,7 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 
 @Component
+@groovy.transform.CompileStatic
 class PythonEnvironmentHandler {
     private final Logger logger = LoggerFactory.getLogger(PythonEnvironmentHandler.class)
     private final String VIRTUAL_ENV_NAME = 'venv'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
@@ -32,7 +32,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeI
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class GemlockNodeParser {
     private final Logger logger = LoggerFactory.getLogger(GemlockNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
@@ -32,7 +32,9 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeI
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class GemlockNodeParser {
     private final Logger logger = LoggerFactory.getLogger(GemlockNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
@@ -27,12 +27,12 @@ import org.slf4j.LoggerFactory
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeImpl
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 
+@groovy.transform.CompileStatic
 class GemlockNodeParser {
     private final Logger logger = LoggerFactory.getLogger(GemlockNodeParser.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
@@ -28,8 +28,10 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 public class RubygemsNodePackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
@@ -29,7 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class RubygemsNodePackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/RubygemsNodePackager.groovy
@@ -29,6 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
 
 @Component
+@groovy.transform.CompileStatic
 public class RubygemsNodePackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtAggregate {
     public String name
     public String org

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtAggregate {
     public String name
     public String org

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtAggregate.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
+@groovy.transform.CompileStatic
 public class SbtAggregate {
     public String name
     public String org
@@ -42,11 +43,11 @@ public class SbtAggregate {
     }
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((org == null) ? 0 : org.hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
-        return result;
+        final int prime = 31
+        int result = 1
+        result = prime * result + ((name == null) ? 0 : name.hashCode())
+        result = prime * result + ((org == null) ? 0 : org.hashCode())
+        result = prime * result + ((version == null) ? 0 : version.hashCode())
+        return result
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
@@ -29,7 +29,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtConfigurationAggregator {
     private final Logger logger = LoggerFactory.getLogger(SbtConfigurationAggregator.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
@@ -29,6 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 
+@groovy.transform.CompileStatic
 public class SbtConfigurationAggregator {
     private final Logger logger = LoggerFactory.getLogger(SbtConfigurationAggregator.class)
 
@@ -39,7 +40,7 @@ public class SbtConfigurationAggregator {
             DependencyNode root = new DependencyNode(new MavenExternalId(aggregate.org, aggregate.name, aggregate.version))
             root.name = aggregate.name
             root.version = aggregate.version
-            root.children = new ArrayList<DependencyNode>()
+            root.children = new HashSet<DependencyNode>()
             configurations.each {config ->
                 if (configurationEqualsAggregate(config, aggregate)) {
                     root.children.addAll(config.rootNode.children)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtConfigurationAggregator.groovy
@@ -29,7 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenExternalId
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtConfigurationAggregator {
     private final Logger logger = LoggerFactory.getLogger(SbtConfigurationAggregator.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
@@ -28,6 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenE
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtReport
 
+@groovy.transform.CompileStatic
 public class SbtDependencyResolver {
     public SbtConfigurationDependencyTree resolveReportDependencies(SbtReport report) {
         def rootId = new MavenExternalId(report.organisation, report.module, report.revision)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
@@ -28,7 +28,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenE
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtReport
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtDependencyResolver {
     public SbtConfigurationDependencyTree resolveReportDependencies(SbtReport report) {
         def rootId = new MavenExternalId(report.organisation, report.module, report.revision)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtDependencyResolver.groovy
@@ -28,7 +28,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.MavenE
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtReport
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtDependencyResolver {
     public SbtConfigurationDependencyTree resolveReportDependencies(SbtReport report) {
         def rootId = new MavenExternalId(report.organisation, report.module, report.revision)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class SbtModule {
     public String sourcePath
     public DependencyNode root

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
+@groovy.transform.CompileStatic
 class SbtModule {
     public String sourcePath
     public DependencyNode root

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtModule.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SbtModule {
     public String sourcePath
     public DependencyNode root

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
@@ -29,7 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.util.ExcludedIncludedFilter
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtPackager {
     private final Logger logger = LoggerFactory.getLogger(SbtPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
@@ -29,6 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.util.ExcludedIncludedFilter
 
+@groovy.transform.CompileStatic
 public class SbtPackager {
     private final Logger logger = LoggerFactory.getLogger(SbtPackager.class)
 
@@ -44,7 +45,7 @@ public class SbtPackager {
             def report = parser.parseReportFromXml(xml)
             def tree = resolver.resolveReportDependencies(report)
             tree
-        };
+        }
 
         def includedConfigurations = configurations.findAll { tree ->
             filter.shouldInclude(tree.configuration)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtPackager.groovy
@@ -29,7 +29,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtConfigurationDependencyTree
 import com.blackducksoftware.integration.util.ExcludedIncludedFilter
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtPackager {
     private final Logger logger = LoggerFactory.getLogger(SbtPackager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
@@ -25,8 +25,8 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.ExternalId
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
+@groovy.transform.CompileStatic
 class SbtProject {
-
     public String projectName
     public String projectVersion
     public ExternalId projectExternalId

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
@@ -25,7 +25,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.ExternalId
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SbtProject {
     public String projectName
     public String projectVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/SbtProject.groovy
@@ -25,7 +25,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.ExternalId
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class SbtProject {
     public String projectName
     public String projectVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
+@groovy.transform.CompileStatic
 public class SbtCaller {
     String callerOrganisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtCaller {
     String callerOrganisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtCaller.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtCaller {
     String callerOrganisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
@@ -20,12 +20,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models;
+package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode;
+import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
-public class SbtConfigurationDependencyTree {
-    String configuration;
+@groovy.transform.CompileStatic
+class SbtConfigurationDependencyTree {
+    String configuration
 
-    DependencyNode rootNode;
+    DependencyNode rootNode
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SbtConfigurationDependencyTree {
     String configuration
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtConfigurationDependencyTree.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class SbtConfigurationDependencyTree {
     String configuration
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtModule {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-
+@groovy.transform.CompileStatic
 public class SbtModule {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtModule.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtModule {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtReport {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtReport {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtReport.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
+@groovy.transform.CompileStatic
 public class SbtReport {
     String organisation
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class SbtRevision {
     String name
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
+@groovy.transform.CompileStatic
 public class SbtRevision {
     String name
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/sbt/models/SbtRevision.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.sbt.models
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class SbtRevision {
     String name
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
@@ -35,7 +35,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVers
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class YarnPackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
@@ -34,8 +34,10 @@ import com.blackducksoftware.integration.hub.detect.nameversion.builder.LinkedNa
 import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVersionNodeBuilderImpl
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class YarnPackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
@@ -35,6 +35,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.builder.NameVers
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
 @Component
+@groovy.transform.CompileStatic
 class YarnPackager {
     @Autowired
     NameVersionNodeTransformer nameVersionNodeTransformer
@@ -80,7 +81,9 @@ class YarnPackager {
             }
         }
 
-        nameVersionLinkNodeBuilder.build().children.collect { nameVersionNodeTransformer.createDependencyNode(Forge.NPM, it) } as Set
+        nameVersionLinkNodeBuilder.build().children.collect {
+            nameVersionNodeTransformer.createDependencyNode(Forge.NPM, it)
+        } as Set
     }
 
     private int getLineLevel(String line) {
@@ -111,16 +114,16 @@ class YarnPackager {
 
     private NameVersionNode lineToNameVersionNode(NameVersionNodeBuilderImpl nameVersionNodeBuilder, NameVersionNode root, String line) {
         String cleanLine = line.replace('"', '').replace(':', '')
-        List<String> fuzzyNames = cleanLine.split(',').collect { it.trim() }
+        List<String> fuzzyNames = cleanLine.split(',').collect { String name -> name.trim() }
 
         if (fuzzyNames.isEmpty()) {
             return null
         }
 
-        String name = cleanFuzzyName(fuzzyNames[0])
+        String name = cleanFuzzyName(fuzzyNames[0] as String)
 
         NameVersionNode linkedNameVersionNode = new NameVersionNodeImpl()
-        linkedNameVersionNode.name = cleanFuzzyName(fuzzyNames[0])
+        linkedNameVersionNode.name = cleanFuzzyName(fuzzyNames[0] as String)
 
         fuzzyNames.each {
             def nameVersionLinkNode = new NameVersionNodeImpl()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.exception;
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked;
+
+@TypeChecked
 public class DetectException extends Exception {
     public DetectException() {
         super();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.exception;
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class DetectException extends Exception {
     public DetectException() {
         super();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/exception/DetectException.java
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.exception;
 
+@groovy.transform.CompileStatic
 public class DetectException extends Exception {
     public DetectException() {
         super();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.help
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 public class DetectOption {
     final String key
     final String description

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.help
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class DetectOption {
     final String key
     final String description

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/DetectOption.groovy
@@ -20,8 +20,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.blackducksoftware.integration.hub.detect.help;
+package com.blackducksoftware.integration.hub.detect.help
 
+@groovy.transform.CompileStatic
 public class DetectOption {
     final String key
     final String description

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
@@ -26,8 +26,10 @@ import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class HelpPrinter {
     @Autowired
     ValueDescriptionAnnotationFinder valueDescriptionAnnotationFinder

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class HelpPrinter {
     @Autowired
     ValueDescriptionAnnotationFinder valueDescriptionAnnotationFinder

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/HelpPrinter.groovy
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
+@groovy.transform.CompileStatic
 class HelpPrinter {
     @Autowired
     ValueDescriptionAnnotationFinder valueDescriptionAnnotationFinder
@@ -66,7 +67,7 @@ class HelpPrinter {
         helpMessagePieces.add('\t--<property name>=<value>')
         helpMessagePieces.add('')
 
-        printStream.println(StringUtils.join(helpMessagePieces, System.getProperty("line.separator")))
+        printStream.println(helpMessagePieces.join(System.getProperty("line.separator")))
     }
 
     private String formatColumns(List<String> columns, int... columnWidths) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ValueDescription {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
@@ -27,7 +27,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked;
+
+@TypeChecked
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ValueDescription {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescription.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@groovy.transform.CompileStatic
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ValueDescription {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
@@ -22,7 +22,8 @@
  */
 package com.blackducksoftware.integration.hub.detect.help
 
-import org.apache.commons.lang3.StringUtils
+import java.lang.reflect.Field
+
 import org.apache.commons.lang3.math.NumberUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -34,6 +35,7 @@ import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
 @Component
+@groovy.transform.CompileStatic
 public class ValueDescriptionAnnotationFinder implements ApplicationContextAware {
     private final Logger logger = LoggerFactory.getLogger(ValueDescriptionAnnotationFinder.class)
 
@@ -48,13 +50,13 @@ public class ValueDescriptionAnnotationFinder implements ApplicationContextAware
 
     public void init() {
         Map<String, DetectOption> detectOptionsMap = [:]
-        applicationContext.beanDefinitionNames.each { beanName ->
+        applicationContext.beanDefinitionNames.each { String beanName ->
             final Object obj = applicationContext.getBean(beanName)
             Class<?> objClz = obj.getClass()
             if (AopUtils.isAopProxy(obj)) {
                 objClz = AopUtils.getTargetClass(obj)
             }
-            objClz.declaredFields.each { field ->
+            objClz.declaredFields.each { Field field ->
                 if (field.isAnnotationPresent(ValueDescription.class)) {
                     String key = ''
                     String description = ''
@@ -73,22 +75,22 @@ public class ValueDescriptionAnnotationFinder implements ApplicationContextAware
                     } else {
                         key = valueDescription.key().trim()
                     }
-                    field.setAccessible(true);
+                    field.setAccessible(true)
                     Object fieldValue = field.get(obj)
                     if (defaultValue?.trim()) {
                         try {
                             Class type = field.getType()
-                            if (String.class.equals(type) && StringUtils.isBlank(fieldValue)) {
-                                field.set(obj, defaultValue);
-                            } else if (Integer.class.equals(type) && fieldValue == null) {
-                                field.set(obj, NumberUtils.toInt(defaultValue));
-                            } else if (Long.class.equals(type) && fieldValue == null) {
-                                field.set(obj, NumberUtils.toLong(defaultValue));
-                            } else if (Boolean.class.equals(type) && fieldValue == null) {
-                                field.set(obj, Boolean.parseBoolean(defaultValue));
+                            if (String.class == type && fieldValue == null) {
+                                field.set(obj, defaultValue)
+                            } else if (Integer.class == type && fieldValue == null) {
+                                field.set(obj, NumberUtils.toInt(defaultValue))
+                            } else if (Long.class == type && fieldValue == null) {
+                                field.set(obj, NumberUtils.toLong(defaultValue))
+                            } else if (Boolean.class == type && fieldValue == null) {
+                                field.set(obj, Boolean.parseBoolean(defaultValue))
                             }
                         } catch (final IllegalAccessException e) {
-                            logger.error(String.format("Could not set defaultValue on field %s with %s: %s", field.getName(), defaultValue, e.getMessage()));
+                            logger.error(String.format("Could not set defaultValue on field %s with %s: %s", field.getName(), defaultValue, e.getMessage()))
                         }
                     }
                     if (!detectOptionsMap.containsKey(key)) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
@@ -34,8 +34,10 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 public class ValueDescriptionAnnotationFinder implements ApplicationContextAware {
     private final Logger logger = LoggerFactory.getLogger(ValueDescriptionAnnotationFinder.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/help/ValueDescriptionAnnotationFinder.groovy
@@ -35,7 +35,7 @@ import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class ValueDescriptionAnnotationFinder implements ApplicationContextAware {
     private final Logger logger = LoggerFactory.getLogger(ValueDescriptionAnnotationFinder.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -32,11 +32,10 @@ import com.blackducksoftware.integration.hub.buildtool.BuildToolConstants
 import com.blackducksoftware.integration.hub.dataservice.phonehome.PhoneHomeDataService
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.global.HubServerConfig
-import com.blackducksoftware.integration.hub.service.HubServicesFactory
-import com.blackducksoftware.integration.log.Slf4jIntLogger
 import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody
 
 @Component
+@groovy.transform.CompileStatic
 class BdioUploader {
     private final Logger logger = LoggerFactory.getLogger(BdioUploader.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -35,7 +35,7 @@ import com.blackducksoftware.integration.hub.global.HubServerConfig
 import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class BdioUploader {
     private final Logger logger = LoggerFactory.getLogger(BdioUploader.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -34,8 +34,10 @@ import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.global.HubServerConfig
 import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class BdioUploader {
     private final Logger logger = LoggerFactory.getLogger(BdioUploader.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
@@ -53,6 +53,7 @@ import com.blackducksoftware.integration.hub.model.view.ScanSummaryView
 import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuilder
 
 @Component
+@groovy.transform.CompileStatic
 class HubManager {
     private final Logger logger = LoggerFactory.getLogger(HubManager.class)
 
@@ -121,14 +122,14 @@ class HubManager {
             if (detectConfiguration.getRiskReportPdf()) {
                 RiskReportDataService riskReportDataService = hubServiceWrapper.createRiskReportDataService()
                 logger.info("Creating risk report pdf")
-                File pdfFile = riskReportDataService.createReportPdfFile(detectConfiguration.riskReportPdfOutputDirectory, detectProject.projectName, detectProject.projectVersionName)
+                File pdfFile = riskReportDataService.createReportPdfFile(new File(detectConfiguration.riskReportPdfOutputDirectory), detectProject.projectName, detectProject.projectVersionName)
                 logger.info("Created risk report pdf : ${pdfFile.getCanonicalPath()}")
             }
 
             if (detectConfiguration.getNoticesReport()) {
                 RiskReportDataService riskReportDataService = hubServiceWrapper.createRiskReportDataService()
                 logger.info("Creating notices report")
-                File noticesFile = riskReportDataService.createNoticesReportFile(detectConfiguration.noticesReportOutputDirectory, detectProject.projectName, detectProject.projectVersionName);
+                File noticesFile = riskReportDataService.createNoticesReportFile(new File(detectConfiguration.noticesReportOutputDirectory), detectProject.projectName, detectProject.projectVersionName)
                 if (noticesFile != null) {
                     logger.info("Created notices report : ${noticesFile.getCanonicalPath()}")
                 }
@@ -152,15 +153,6 @@ class HubManager {
             logger.debug(e.getMessage(), e)
         }
         postActionResult
-    }
-
-    private void performScan(DetectProject detectProject) {
-        if (!detectConfiguration.getHubSignatureScannerDisabled()) {
-            ProjectVersionView scanProject = hubSignatureScanner.scanPaths(hubServerConfig, hubServicesFactory.createCLIDataService(slf4jIntLogger, 120000L), detectProject)
-            if (!projectVersionView) {
-                projectVersionView = scanProject
-            }
-        }
     }
 
     public void waitForBomUpdate(ProjectDataService projectDataService, CodeLocationRequestService codeLocationRequestService, MetaService metaService, ScanSummaryRequestService scanSummaryRequestService, ScanStatusDataService scanStatusDataService, ProjectVersionView version) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
@@ -52,8 +52,10 @@ import com.blackducksoftware.integration.hub.model.view.ProjectView
 import com.blackducksoftware.integration.hub.model.view.ScanSummaryView
 import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuilder
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class HubManager {
     private final Logger logger = LoggerFactory.getLogger(HubManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
@@ -53,7 +53,7 @@ import com.blackducksoftware.integration.hub.model.view.ScanSummaryView
 import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuilder
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class HubManager {
     private final Logger logger = LoggerFactory.getLogger(HubManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
@@ -48,8 +48,10 @@ import com.blackducksoftware.integration.hub.rest.RestConnection
 import com.blackducksoftware.integration.hub.service.HubServicesFactory
 import com.blackducksoftware.integration.log.Slf4jIntLogger
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class HubServiceWrapper {
     private final Logger logger = LoggerFactory.getLogger(HubServiceWrapper.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
@@ -46,17 +46,17 @@ import com.blackducksoftware.integration.hub.detect.exception.DetectException
 import com.blackducksoftware.integration.hub.global.HubServerConfig
 import com.blackducksoftware.integration.hub.rest.RestConnection
 import com.blackducksoftware.integration.hub.service.HubServicesFactory
-import com.blackducksoftware.integration.log.IntLogger
 import com.blackducksoftware.integration.log.Slf4jIntLogger
 
 @Component
+@groovy.transform.CompileStatic
 class HubServiceWrapper {
     private final Logger logger = LoggerFactory.getLogger(HubServiceWrapper.class)
 
     @Autowired
     DetectConfiguration detectConfiguration
 
-    IntLogger slf4jIntLogger
+    Slf4jIntLogger slf4jIntLogger
     HubServerConfig hubServerConfig
     HubServicesFactory hubServicesFactory
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
@@ -49,7 +49,7 @@ import com.blackducksoftware.integration.hub.service.HubServicesFactory
 import com.blackducksoftware.integration.log.Slf4jIntLogger
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class HubServiceWrapper {
     private final Logger logger = LoggerFactory.getLogger(HubServiceWrapper.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -38,8 +38,10 @@ import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuilder
 import com.blackducksoftware.integration.hub.scan.HubScanConfig
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class HubSignatureScanner {
     private final Logger logger = LoggerFactory.getLogger(HubSignatureScanner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -39,7 +39,7 @@ import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuild
 import com.blackducksoftware.integration.hub.scan.HubScanConfig
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class HubSignatureScanner {
     private final Logger logger = LoggerFactory.getLogger(HubSignatureScanner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -39,6 +39,7 @@ import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuild
 import com.blackducksoftware.integration.hub.scan.HubScanConfig
 
 @Component
+@groovy.transform.CompileStatic
 class HubSignatureScanner {
     private final Logger logger = LoggerFactory.getLogger(HubSignatureScanner.class)
 
@@ -91,8 +92,8 @@ class HubSignatureScanner {
     public ProjectVersionView scanPaths(HubServerConfig hubServerConfig, CLIDataService cliDataService, DetectProject detectProject) {
         ProjectVersionView projectVersionView = null
         if (detectProject.projectName && detectProject.projectVersionName && detectConfiguration.hubSignatureScannerPaths) {
-            detectConfiguration.hubSignatureScannerPaths.each {
-                projectVersionView = scanPath(cliDataService, hubServerConfig, new File(it).canonicalPath, detectProject)
+            detectConfiguration.hubSignatureScannerPaths.each { String path ->
+                projectVersionView = scanPath(cliDataService, hubServerConfig, new File(path).canonicalPath, detectProject)
             }
         } else {
             registeredPaths.each {
@@ -108,8 +109,8 @@ class HubSignatureScanner {
 
     public void scanPathsOffline(DetectProject detectProject) {
         if (detectProject.projectName && detectProject.projectVersionName && detectConfiguration.hubSignatureScannerPaths) {
-            detectConfiguration.hubSignatureScannerPaths.each {
-                scanPathOffline(new File(it).canonicalPath, detectProject)
+            detectConfiguration.hubSignatureScannerPaths.each { String path ->
+                scanPathOffline(new File(path).canonicalPath, detectProject)
             }
         } else {
             registeredPaths.each {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/OfflineScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/OfflineScanner.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.util.CIEnvironmentVariables
 import com.google.gson.Gson
 
 @Component
+@groovy.transform.TypeChecked // Type checked to access private method
 class OfflineScanner {
     private static final Logger logger = LoggerFactory.getLogger(OfflineScanner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/OfflineScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/OfflineScanner.groovy
@@ -36,8 +36,10 @@ import com.blackducksoftware.integration.log.Slf4jIntLogger
 import com.blackducksoftware.integration.util.CIEnvironmentVariables
 import com.google.gson.Gson
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked // Type checked to access private method
+@TypeChecked
 class OfflineScanner {
     private static final Logger logger = LoggerFactory.getLogger(OfflineScanner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
@@ -36,7 +36,7 @@ import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.hub.model.view.VersionBomPolicyStatusView
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class PolicyChecker {
     private final Logger logger = LoggerFactory.getLogger(PolicyChecker.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
@@ -35,8 +35,10 @@ import com.blackducksoftware.integration.hub.model.enumeration.VersionBomPolicyS
 import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.hub.model.view.VersionBomPolicyStatusView
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class PolicyChecker {
     private final Logger logger = LoggerFactory.getLogger(PolicyChecker.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/PolicyChecker.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.hub.model.view.VersionBomPolicyStatusView
 
 @Component
+@groovy.transform.CompileStatic
 class PolicyChecker {
     private final Logger logger = LoggerFactory.getLogger(PolicyChecker.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 interface NameVersionNode {
     public String getName()
     public String getVersion()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 interface NameVersionNode {
     public String getName()
     public String getVersion()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
+@groovy.transform.CompileStatic
 interface NameVersionNode {
     public String getName()
     public String getVersion()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
@@ -26,11 +26,11 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 interface NameVersionNode {
     public String getName()
     public String getVersion()
-    public List<? extends NameVersionNode> getChildren()
+    public List<NameVersionNode> getChildren()
     public NodeMetadata getMetadata()
 
     public void setName(String name)
     public void setVersion(String version)
-    public void setChildren(List<? extends NameVersionNode> children)
+    public void setChildren(List<NameVersionNode> children)
     public void setMetadata(NodeMetadata metadata)
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNode.groovy
@@ -26,11 +26,11 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 interface NameVersionNode {
     public String getName()
     public String getVersion()
-    public List<NameVersionNode> getChildren()
+    public List<? extends NameVersionNode> getChildren()
     public NodeMetadata getMetadata()
 
     public void setName(String name)
     public void setVersion(String version)
-    public void setChildren(List<NameVersionNode> children)
+    public void setChildren(List<? extends NameVersionNode> children)
     public void setMetadata(NodeMetadata metadata)
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 interface NameVersionNodeBuilder {
     public NameVersionNode getRoot()
     public NameVersionNode build()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 interface NameVersionNodeBuilder {
     public NameVersionNode getRoot()
     public NameVersionNode build()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeBuilder.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.nameversion
 
+@groovy.transform.CompileStatic
 interface NameVersionNodeBuilder {
     public NameVersionNode getRoot()
     public NameVersionNode build()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
@@ -25,7 +25,9 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 import org.apache.commons.lang3.builder.RecursiveToStringStyle
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class NameVersionNodeImpl implements NameVersionNode {
     String name
     String version

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
@@ -25,7 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 import org.apache.commons.lang3.builder.RecursiveToStringStyle
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NameVersionNodeImpl implements NameVersionNode {
     String name
     String version

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeImpl.groovy
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 import org.apache.commons.lang3.builder.RecursiveToStringStyle
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder
 
+@groovy.transform.CompileStatic
 class NameVersionNodeImpl implements NameVersionNode {
     String name
     String version

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
@@ -29,6 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 
 @Component
+@groovy.transform.CompileStatic
 class NameVersionNodeTransformer {
     public DependencyNode createDependencyNode(Forge defaultForge, NameVersionNode nameVersionNode) {
         final Forge forge = nameVersionNode.metadata?.forge ? nameVersionNode.metadata.forge : defaultForge

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
@@ -29,7 +29,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NameVersionNodeTransformer {
     public DependencyNode createDependencyNode(Forge defaultForge, NameVersionNode nameVersionNode) {
         final Forge forge = nameVersionNode.metadata?.forge ? nameVersionNode.metadata.forge : defaultForge

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NameVersionNodeTransformer.groovy
@@ -28,8 +28,10 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class NameVersionNodeTransformer {
     public DependencyNode createDependencyNode(Forge defaultForge, NameVersionNode nameVersionNode) {
         final Forge forge = nameVersionNode.metadata?.forge ? nameVersionNode.metadata.forge : defaultForge

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 interface NodeMetadata {
     public Forge getForge()
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
@@ -24,6 +24,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 
+@groovy.transform.CompileStatic
 interface NodeMetadata {
     public Forge getForge()
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/NodeMetadata.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.nameversion
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 interface NodeMetadata {
     public Forge getForge()
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
+@groovy.transform.TypeChecked
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
     public LinkedNameVersionNodeBuilder(NameVersionNode root) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -25,7 +25,6 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
-@groovy.transform.TypeChecked
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
     public LinkedNameVersionNodeBuilder(NameVersionNode root) {
@@ -38,9 +37,7 @@ class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
         Set<String> cyclicalNames = new HashSet<>()
 
         NameVersionNode resolved = resolveLinks(cyclicalNames, cyclicalStack, root)
-        cyclicalNames.each {
-            logger.debug("Cyclical depdency detected: ${it}")
-        }
+        cyclicalNames.each { logger.debug("Cyclical depdency detected: ${it}") }
 
         resolved
     }
@@ -66,7 +63,7 @@ class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
         if (resolvedNode) {
             List<NameVersionNode> resolvedChildren = []
-            for (NameVersionNode child : nameVersionNode.children) {
+            for (NameVersionNode child : resolvedNode.children) {
                 NameVersionNode resolvedChild = resolveLinks(cyclicalNames, cyclicalStack, child)
                 if (resolvedChild) {
                     resolvedChildren.add(resolvedChild)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -27,7 +27,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMet
 
 import groovy.transform.CompileStatic
 
-@CompileStatic
+@groovy.transform.CompileStatic
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
     public LinkedNameVersionNodeBuilder(NameVersionNode root) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -25,8 +25,6 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
-import groovy.transform.CompileStatic
-
 @groovy.transform.TypeChecked
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
@@ -40,7 +38,9 @@ class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
         Set<String> cyclicalNames = new HashSet<>()
 
         NameVersionNode resolved = resolveLinks(cyclicalNames, cyclicalStack, root)
-        cyclicalNames.each { logger.debug("Cyclical depdency detected: ${it}") }
+        cyclicalNames.each {
+            logger.debug("Cyclical depdency detected: ${it}")
+        }
 
         resolved
     }
@@ -66,8 +66,8 @@ class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
         if (resolvedNode) {
             List<NameVersionNode> resolvedChildren = []
-            resolvedNode.children.each {
-                NameVersionNode resolvedChild = resolveLinks(cyclicalNames, cyclicalStack, it)
+            for (NameVersionNode child : nameVersionNode.children) {
+                NameVersionNode resolvedChild = resolveLinks(cyclicalNames, cyclicalStack, child)
                 if (resolvedChild) {
                     resolvedChildren.add(resolvedChild)
                 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -25,7 +25,9 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMetadata
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
     public LinkedNameVersionNodeBuilder(NameVersionNode root) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/LinkedNameVersionNodeBuilder.groovy
@@ -27,7 +27,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.metadata.LinkMet
 
 import groovy.transform.CompileStatic
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class LinkedNameVersionNodeBuilder extends NameVersionNodeBuilderImpl {
 
     public LinkedNameVersionNodeBuilder(NameVersionNode root) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
@@ -34,7 +34,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
  * always have a defined version for each dependency, but will EVENTUALLY find
  * a defined version, as in Gemfile.lock files.
  */
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class NameVersionNodeBuilderImpl implements NameVersionNodeBuilder {
     final Logger logger = LoggerFactory.getLogger(NameVersionNodeBuilderImpl.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
@@ -29,12 +29,14 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeBuilder
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
+import groovy.transform.TypeChecked
+
 /**
  * This class should be used to construct node graphs where you don't
  * always have a defined version for each dependency, but will EVENTUALLY find
  * a defined version, as in Gemfile.lock files.
  */
-@groovy.transform.TypeChecked
+@TypeChecked
 class NameVersionNodeBuilderImpl implements NameVersionNodeBuilder {
     final Logger logger = LoggerFactory.getLogger(NameVersionNodeBuilderImpl.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/NameVersionNodeBuilderImpl.groovy
@@ -34,6 +34,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
  * always have a defined version for each dependency, but will EVENTUALLY find
  * a defined version, as in Gemfile.lock files.
  */
+@groovy.transform.CompileStatic
 class NameVersionNodeBuilderImpl implements NameVersionNodeBuilder {
     final Logger logger = LoggerFactory.getLogger(NameVersionNodeBuilderImpl.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.SubcomponentMetadata
 
+@groovy.transform.CompileStatic
 class SubcomponentNodeBuilder extends LinkedNameVersionNodeBuilder {
     List<NameVersionNode> superComponents = []
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
@@ -25,7 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.SubcomponentMetadata
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SubcomponentNodeBuilder extends LinkedNameVersionNodeBuilder {
     List<NameVersionNode> superComponents = []
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/builder/SubcomponentNodeBuilder.groovy
@@ -25,7 +25,18 @@ package com.blackducksoftware.integration.hub.detect.nameversion.builder
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.metadata.SubcomponentMetadata
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+/**
+ * The use for this is because the KB currently does not support sub components in
+ * cocoapods. Until such time we must collapse sub commponents into their super component
+ *
+ * Takes the children of a NameVersionNode and moves them to the super component.
+ * Subcomponents should have a link to the superComponent in the metadata.
+ * The superComponents should have all subcomponents in their metadata.
+ * All superComponents should be added the the superComponents list.
+ */
+@TypeChecked
 class SubcomponentNodeBuilder extends LinkedNameVersionNodeBuilder {
     List<NameVersionNode> superComponents = []
 
@@ -40,15 +51,6 @@ class SubcomponentNodeBuilder extends LinkedNameVersionNodeBuilder {
         super.build()
     }
 
-    /**
-     * The use for this is because the KB currently does not support sub components in
-     * cocoapods. Until such time we must collapse sub commponents into their super component
-     *
-     * Takes the children of a NameVersionNode and moves them to the super component.
-     * Subcomponents should have a link to the superComponent in the metadata.
-     * The superComponents should have all subcomponents in their metadata.
-     * All superComponents should be added the the superComponents list.
-     */
     public NameVersionNode collapseSubcomponents(NameVersionNode nameVersionNode) {
         if (nameVersionNode?.metadata instanceof SubcomponentMetadata) {
             SubcomponentMetadata metadata = nameVersionNode.metadata as SubcomponentMetadata
@@ -59,7 +61,7 @@ class SubcomponentNodeBuilder extends LinkedNameVersionNodeBuilder {
                 if (version && subcomponentVersion) {
                     nameVersionNode.version = subcomponentVersion
                 }
-                nameVersionNode.children.addAll(subcomponent.children.collect { collapseSubcomponents(it) })
+                nameVersionNode.children.addAll(subcomponent.children.collect { collapseSubcomponents(it as NameVersionNode) })
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
@@ -26,7 +26,9 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class LinkMetadata implements NodeMetadata {
     Forge forge
     NameVersionNode linkNode

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
@@ -26,7 +26,7 @@ import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class LinkMetadata implements NodeMetadata {
     Forge forge
     NameVersionNode linkNode

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/LinkMetadata.groovy
@@ -23,9 +23,10 @@
 package com.blackducksoftware.integration.hub.detect.nameversion.metadata
 
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
-import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
+import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
+@groovy.transform.CompileStatic
 class LinkMetadata implements NodeMetadata {
     Forge forge
     NameVersionNode linkNode

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
@@ -25,7 +25,9 @@ package com.blackducksoftware.integration.hub.detect.nameversion.metadata
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class MetadataImpl implements NodeMetadata {
     Forge forge
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
@@ -25,7 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion.metadata
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class MetadataImpl implements NodeMetadata {
     Forge forge
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/MetadataImpl.groovy
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.nameversion.metadata
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.detect.nameversion.NodeMetadata
 
+@groovy.transform.CompileStatic
 class MetadataImpl implements NodeMetadata {
     Forge forge
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
@@ -27,7 +27,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import groovy.transform.ToString
 
 @ToString
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class SubcomponentMetadata extends LinkMetadata {
     List<NameVersionNode> subcomponents = []
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
@@ -27,6 +27,7 @@ import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 import groovy.transform.ToString
 
 @ToString
+@groovy.transform.CompileStatic
 class SubcomponentMetadata extends LinkMetadata {
     List<NameVersionNode> subcomponents = []
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/nameversion/metadata/SubcomponentMetadata.groovy
@@ -25,9 +25,10 @@ package com.blackducksoftware.integration.hub.detect.nameversion.metadata
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNode
 
 import groovy.transform.ToString
+import groovy.transform.TypeChecked
 
 @ToString
-@groovy.transform.TypeChecked
+@TypeChecked
 class SubcomponentMetadata extends LinkMetadata {
     List<NameVersionNode> subcomponents = []
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.type
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 enum ExecutableType {
     BASH([(OperatingSystemType.WINDOWS): 'bash.exe', (OperatingSystemType.LINUX): 'bash']),
     CONDA([(OperatingSystemType.WINDOWS): 'conda.exe', (OperatingSystemType.LINUX): 'conda']),

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.type
 
+@groovy.transform.CompileStatic
 enum ExecutableType {
     BASH([(OperatingSystemType.WINDOWS): 'bash.exe', (OperatingSystemType.LINUX): 'bash']),
     CONDA([(OperatingSystemType.WINDOWS): 'conda.exe', (OperatingSystemType.LINUX): 'conda']),

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.type
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 enum ExecutableType {
     BASH([(OperatingSystemType.WINDOWS): 'bash.exe', (OperatingSystemType.LINUX): 'bash']),
     CONDA([(OperatingSystemType.WINDOWS): 'conda.exe', (OperatingSystemType.LINUX): 'conda']),

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.type;
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public enum OperatingSystemType {
     LINUX,
     MAC,

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.type;
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked;
+
+@TypeChecked
 public enum OperatingSystemType {
     LINUX,
     MAC,

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/OperatingSystemType.java
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.type;
 
+@groovy.transform.CompileStatic
 public enum OperatingSystemType {
     LINUX,
     MAC,

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -32,6 +32,7 @@ import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
 @Component
+@groovy.transform.CompileStatic
 class DetectFileManager {
     private final Logger logger = LoggerFactory.getLogger(DetectFileManager.class)
 
@@ -128,7 +129,7 @@ class DetectFileManager {
     }
 
     public File[] findFilesToDepth(String sourceDirectory, String filenamePattern, int maxDepth) {
-        return findFilesToDepth(new File(sourceDirectory), filenamePattern, maxDepth);
+        return findFilesToDepth(new File(sourceDirectory), filenamePattern, maxDepth)
     }
 
     public File[] findFilesToDepth(File sourceDirectory, String filenamePattern, int maxDepth) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -31,8 +31,10 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class DetectFileManager {
     private final Logger logger = LoggerFactory.getLogger(DetectFileManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -32,7 +32,7 @@ import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class DetectFileManager {
     private final Logger logger = LoggerFactory.getLogger(DetectFileManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
@@ -27,7 +27,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
+import groovy.transform.TypeChecked
+
 @Component
+@TypeChecked
 class FileFinder {
     private final Logger logger = LoggerFactory.getLogger(FileFinder.class)
 
@@ -105,17 +108,17 @@ class FileFinder {
     private File[] findFilesRecursive(final File sourceDirectory, final String filenamePattern, int currentDepth, int maxDepth) {
         def files = []
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
-            return files
+            return files as File[]
         }
-        sourceDirectory.listFiles().each {
-            if (FilenameUtils.wildcardMatchOnSystem(it.getName(), filenamePattern)) {
-                files.add(it)
+        sourceDirectory.listFiles().each { File file ->
+            if (FilenameUtils.wildcardMatchOnSystem(file.getName(), filenamePattern)) {
+                files.add(file)
             }
-            if (it.isDirectory()) {
-                files.addAll(findFilesRecursive(it, filenamePattern, currentDepth + 1, maxDepth))
+            if (file.isDirectory()) {
+                files.addAll(findFilesRecursive(file, filenamePattern, currentDepth + 1, maxDepth))
             }
         }
-        return files
+        return files as File[]
     }
 
     private File[] findDirectoriesContainingDirectoriesToDepth(final File sourceDirectory, final String directoryPattern, int maxDepth) {
@@ -126,20 +129,20 @@ class FileFinder {
 
         def files = []
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
-            return files
+            return files as File[]
         }
 
-        sourceDirectory.listFiles().each {
-            if (it.isDirectory()) {
-                if (FilenameUtils.wildcardMatchOnSystem(it.getName(), directoryPattern)) {
-                    files.add(it)
+        sourceDirectory.listFiles().each { File file ->
+            if (file.isDirectory()) {
+                if (FilenameUtils.wildcardMatchOnSystem(file.getName(), directoryPattern)) {
+                    files.add(file)
                 } else {
-                    files.addAll(findDirectoriesContainingDirectoriesToDepthRecursive(it, directoryPattern, currentDepth + 1, maxDepth))
+                    files.addAll(findDirectoriesContainingDirectoriesToDepthRecursive(file, directoryPattern, currentDepth + 1, maxDepth))
                 }
             }
         }
 
-        return files
+        return files as File[]
     }
 
     File[] findDirectoriesContainingFilesToDepth(final File sourceDirectory, final String filenamePattern, int maxDepth) {
@@ -149,7 +152,7 @@ class FileFinder {
     private File[] findDirectoriesContainingFilesRecursive(final File sourceDirectory, final String filenamePattern, int currentDepth, int maxDepth) {
         def files = new HashSet<File>()
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
-            return files
+            return files as File[]
         }
         for (File file : sourceDirectory.listFiles()) {
             if (file.isDirectory()) {
@@ -158,6 +161,6 @@ class FileFinder {
                 files.add(sourceDirectory)
             }
         }
-        return new ArrayList<File>(files)
+        return new ArrayList<File>(files) as File[]
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
@@ -118,7 +118,7 @@ class FileFinder {
         return files
     }
 
-    public File[] findDirectoriesContainingDirectoriesToDepth(final File sourceDirectory, final String directoryPattern, int maxDepth) {
+    private File[] findDirectoriesContainingDirectoriesToDepth(final File sourceDirectory, final String directoryPattern, int maxDepth) {
         findDirectoriesContainingDirectoriesToDepthRecursive(sourceDirectory, directoryPattern, 0, maxDepth)
     }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/FileFinder.groovy
@@ -103,7 +103,7 @@ class FileFinder {
     }
 
     private File[] findFilesRecursive(final File sourceDirectory, final String filenamePattern, int currentDepth, int maxDepth) {
-        def files = [];
+        def files = []
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
             return files
         }
@@ -118,13 +118,13 @@ class FileFinder {
         return files
     }
 
-    private File[] findDirectoriesContainingDirectoriesToDepth(final File sourceDirectory, final String directoryPattern, int maxDepth) {
-        findDirectoriesContainingDirectoriesToDepthRecursive(sourceDirectory, directoryPattern, 0, maxDepth);
+    public File[] findDirectoriesContainingDirectoriesToDepth(final File sourceDirectory, final String directoryPattern, int maxDepth) {
+        findDirectoriesContainingDirectoriesToDepthRecursive(sourceDirectory, directoryPattern, 0, maxDepth)
     }
 
     private File[] findDirectoriesContainingDirectoriesToDepthRecursive(final File sourceDirectory, final String directoryPattern, int currentDepth, int maxDepth) {
 
-        def files = [];
+        def files = []
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
             return files
         }
@@ -132,14 +132,14 @@ class FileFinder {
         sourceDirectory.listFiles().each {
             if (it.isDirectory()) {
                 if (FilenameUtils.wildcardMatchOnSystem(it.getName(), directoryPattern)) {
-                    files.add(it);
+                    files.add(it)
                 } else {
-                    files.addAll(findDirectoriesContainingDirectoriesToDepthRecursive(it, directoryPattern, currentDepth + 1, maxDepth));
+                    files.addAll(findDirectoriesContainingDirectoriesToDepthRecursive(it, directoryPattern, currentDepth + 1, maxDepth))
                 }
             }
-        };
+        }
 
-        return files;
+        return files
     }
 
     File[] findDirectoriesContainingFilesToDepth(final File sourceDirectory, final String filenamePattern, int maxDepth) {
@@ -147,7 +147,7 @@ class FileFinder {
     }
 
     private File[] findDirectoriesContainingFilesRecursive(final File sourceDirectory, final String filenamePattern, int currentDepth, int maxDepth) {
-        def files = new HashSet<File>();
+        def files = new HashSet<File>()
         if (currentDepth > maxDepth || !sourceDirectory.isDirectory()) {
             return files
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
@@ -24,11 +24,12 @@ package com.blackducksoftware.integration.hub.detect.util.executable
 
 import org.apache.commons.lang3.StringUtils
 
+@groovy.transform.CompileStatic
 class Executable {
     File workingDirectory
-    def environmentVariables = [:]
+    Map<String, String> environmentVariables = [:]
     String executablePath
-    def executableArguments = []
+    List<String> executableArguments = []
 
     Executable(File workingDirectory, final String executablePath, List<String> executableArguments) {
         this.workingDirectory = workingDirectory
@@ -45,7 +46,7 @@ class Executable {
 
     ProcessBuilder createProcessBuilder() {
         def processBuilderArguments = createProcessBuilderArguments()
-        ProcessBuilder processBuilder = new ProcessBuilder(processBuilderArguments);
+        ProcessBuilder processBuilder = new ProcessBuilder(processBuilderArguments)
         processBuilder.directory(workingDirectory)
         def processBuilderEnvironment = processBuilder.environment()
         System.getenv().each { key, value ->

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
@@ -24,7 +24,7 @@ package com.blackducksoftware.integration.hub.detect.util.executable
 
 import org.apache.commons.lang3.StringUtils
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class Executable {
     File workingDirectory
     Map<String, String> environmentVariables = [:]

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/Executable.groovy
@@ -24,7 +24,9 @@ package com.blackducksoftware.integration.hub.detect.util.executable
 
 import org.apache.commons.lang3.StringUtils
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class Executable {
     File workingDirectory
     Map<String, String> environmentVariables = [:]

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
@@ -33,7 +33,7 @@ import com.blackducksoftware.integration.hub.detect.type.OperatingSystemType
 import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class ExecutableManager {
     private final Logger logger = LoggerFactory.getLogger(ExecutableManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
@@ -32,8 +32,10 @@ import com.blackducksoftware.integration.hub.detect.type.ExecutableType
 import com.blackducksoftware.integration.hub.detect.type.OperatingSystemType
 import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 class ExecutableManager {
     private final Logger logger = LoggerFactory.getLogger(ExecutableManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
@@ -33,6 +33,7 @@ import com.blackducksoftware.integration.hub.detect.type.OperatingSystemType
 import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 
 @Component
+@groovy.transform.CompileStatic
 class ExecutableManager {
     private final Logger logger = LoggerFactory.getLogger(ExecutableManager.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class ExecutableOutput {
     final String standardOutput
     final String errorOutput

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
+@groovy.transform.CompileStatic
 class ExecutableOutput {
     final String standardOutput
     final String errorOutput

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableOutput.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class ExecutableOutput {
     final String standardOutput
     final String errorOutput

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
@@ -31,8 +31,10 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
+import groovy.transform.TypeChecked
+
 @Component
-@groovy.transform.TypeChecked
+@TypeChecked
 public class ExecutableRunner {
     private final Logger logger = LoggerFactory.getLogger(ExecutableRunner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
@@ -29,10 +29,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import com.blackducksoftware.integration.hub.detect.Application
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
 @Component
+@groovy.transform.CompileStatic
 public class ExecutableRunner {
     private final Logger logger = LoggerFactory.getLogger(ExecutableRunner.class)
 
@@ -82,7 +82,7 @@ public class ExecutableRunner {
     }
 
     public ExecutableOutput runExe(final String exePath, final String... args) {
-        def exe = new Executable(detectConfiguration.getSourceDirectory(), exePath, args.toList())
+        def exe = new Executable(detectConfiguration.sourceDirectory, exePath, args.toList())
         execute(exe)
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunner.groovy
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 
 @Component
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 public class ExecutableRunner {
     private final Logger logger = LoggerFactory.getLogger(ExecutableRunner.class)
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
+@groovy.transform.CompileStatic
 class ExecutableRunnerException extends Exception {
     ExecutableRunnerException(final Throwable innerException) {
         super(innerException)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
@@ -22,7 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
-@groovy.transform.CompileStatic
+@groovy.transform.TypeChecked
 class ExecutableRunnerException extends Exception {
     ExecutableRunnerException(final Throwable innerException) {
         super(innerException)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableRunnerException.groovy
@@ -22,7 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.detect.util.executable
 
-@groovy.transform.TypeChecked
+import groovy.transform.TypeChecked
+
+@TypeChecked
 class ExecutableRunnerException extends Exception {
     ExecutableRunnerException(final Throwable innerException) {
         super(innerException)


### PR DESCRIPTION
A lot of simple error's that would be caught at compile time are slipping through the cracks and becoming runtime errors. By adding the @TypeChecked annotation to the top of every class, we can help prevent a lot of these mistakes. 

The pros:
A lot of the runtime errors we experience will now surface at runtime
The code will be more defined and easier to read

The cons:
Add @TypeChecked annotation to every class
Some classes may need to be rewritten or tweaked to comply

There is another annotation called @CompileStatic which in addition to type checking, it will statically compile the class. I have opted not to do this because it prevents us from accessing private or read-only fields. @CompileStatic also prevents us from using the ? operator as a null check in some cases, causing null pointer exceptions at runtime where ever they are used.

I have caught a few errors that would have caused run time errors which are fixed in this branch.
I think overall this is a net benefit to the quality and stability of the code, even if it is slightly less flexible