### PR TITLE
Generated properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,11 +182,11 @@ task generateProperties {
 		println 'Generating properties'
 		MustacheFactory mf = new DefaultMustacheFactory()
 		JsonSlurper jsonSlurper = new JsonSlurper()
-		File propertiesJosnFile = new File("${projectDir}/src/main/resources/properties.json")
-		File applicationPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/application.properties.mustache")
-		File applicationPropertiesFile = new File("${projectDir}/src/main/resources/application.properties")
-		File detectPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/DetectProperties.groovy.mustache")
-		File detectPropertiesFile = new File("${projectDir}/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy")
+		File propertiesJosnFile = new File("${projectDir}/src/main/resources/properties.json".replace('/', File.separator))
+		File applicationPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/application.properties.mustache".replace('/', File.separator))
+		File applicationPropertiesFile = new File("${projectDir}/src/main/resources/application.properties".replace('/', File.separator))
+		File detectPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/DetectProperties.groovy.mustache".replace('/', File.separator))
+		File detectPropertiesFile = new File("${projectDir}/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy".replace('/', File.separator))
 		
 		def propertiesFile = new PropertiesFile()
 		def properties = jsonSlurper.parseText(propertiesJosnFile.getText(StandardCharsets.UTF_8.toString()))
@@ -196,7 +196,7 @@ task generateProperties {
 			propertyGroup.each { propertyName, jsonProprety ->
 				def property = new Property(jsonProprety)
 				property.name = propertyName
-				if(property.name.startsWith('logging')) {
+				if (property.name.startsWith('logging')) {
 					property.value = property.defaultValue
 				}
 				property.propertyVariableName = convertToVariableName(property.name)

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     dependencies {
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
+		classpath 'com.github.spullara.mustache.java:compiler:0.8.18'
     }
 }
 
@@ -150,3 +151,18 @@ task downloadNugetAirgapDependencies {
 task updateAirgapDependencies {
     dependsOn cleanAirgapDependencies, downloadGradleAirgapDependencies, downloadNugetAirgapDependencies
 }
+
+
+class Property {
+	String scope
+	String propertyName
+}
+
+task generateProperties {
+	doLast {
+		MustacheFactory mf = new DefaultMustacheFactory()
+		Mustache mustache = mf.compile("mustache/application.properties.mustache")
+	}
+}
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,11 @@
 import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
 
 import com.github.mustachejava.Mustache
 import com.github.mustachejava.DefaultMustacheFactory
 import com.github.mustachejava.MustacheFactory
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets
 
 buildscript {
     repositories {
@@ -60,6 +63,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 build {
+	dependsOn 'generateProperties'
+	
     finalizedBy 'updateAirgapDependencies'
     
     doLast {
@@ -132,6 +137,7 @@ void fetchFile(File outputFile, String url) {
     new URL(url).withInputStream{ i -> outputFile.withOutputStream{ it << i }}
 }
 
+//////////// Air gap dependencies ////////////
 task cleanAirgapDependencies(type: Delete) {
     delete fileTree(gradleAirgapPath)
 }
@@ -152,17 +158,72 @@ task updateAirgapDependencies {
     dependsOn cleanAirgapDependencies, downloadGradleAirgapDependencies, downloadNugetAirgapDependencies
 }
 
+//////////// Propert file generation ////////////
+class PropertiesFile {
+	List<Group> groups = []
+}
+
+class Group {
+	String name
+	String groupVariableName
+	List<Property> properties = []
+}
 
 class Property {
-	String scope
-	String propertyName
+	String name
+	String propertyVariableName
+	String description
+	String defaultValue
+	String type = 'String'
+	String value
 }
 
 task generateProperties {
-	doLast {
+		println 'Generating properties'
 		MustacheFactory mf = new DefaultMustacheFactory()
-		Mustache mustache = mf.compile("mustache/application.properties.mustache")
+		JsonSlurper jsonSlurper = new JsonSlurper()
+		File propertiesJosnFile = new File("${projectDir}/src/main/resources/properties.json")
+		File applicationPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/application.properties.mustache")
+		File applicationPropertiesFile = new File("${projectDir}/src/main/resources/application.properties")
+		File detectPropertiesTemplateFile = new File("${projectDir}/src/main/resources/mustache/DetectProperties.groovy.mustache")
+		File detectPropertiesFile = new File("${projectDir}/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy")
+		
+		def propertiesFile = new PropertiesFile()
+		def properties = jsonSlurper.parseText(propertiesJosnFile.getText(StandardCharsets.UTF_8.toString()))
+		properties.each { groupName, propertyGroup ->
+			def group = new Group([name: groupName])
+			group.groupVariableName = "GROUP_${group.name.toUpperCase().replace(' ', '_')}"
+			propertyGroup.each { propertyName, jsonProprety ->
+				def property = new Property(jsonProprety)
+				property.name = propertyName
+				if(property.name.startsWith('logging')) {
+					property.value = property.defaultValue
+				}
+				property.propertyVariableName = convertToVariableName(property.name)
+				group.properties.add(property)
+			}
+			propertiesFile.groups.add(group)
+		}
+		
+		Mustache applicationPropertiesMustache = mf.compile(applicationPropertiesTemplateFile.getCanonicalPath())
+		applicationPropertiesMustache.execute(new FileWriter(applicationPropertiesFile), propertiesFile).flush();
+		
+		Mustache detectPropertiesMustace = mf.compile(detectPropertiesTemplateFile.getCanonicalPath())
+		detectPropertiesMustace.execute(new FileWriter(detectPropertiesFile), propertiesFile).flush();
+}
+
+private String convertToVariableName(String propertyName) {
+	if (!propertyName?.trim()) {
+		return null
 	}
+	List<String> segments = propertyName.split('\\.').collect{ it.capitalize() }
+	if (segments.isEmpty()) {
+		return null
+	}
+	segments.remove(0)
+	segments[0] = segments[0].toLowerCase()
+	
+	segments.join('')
 }
 
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -91,20 +91,20 @@ class DetectConfiguration {
         //make sure the path is absolute
         detectProperties.sourcePath = sourceDirectory.canonicalPath
 
-        if (StringUtils.isBlank(detectProperties.outputDirectoryPath)) {
+        if (StringUtils.isBlank(detectProperties.outputPath)) {
             usingDefaultOutputPath = true
-            detectProperties.outputDirectoryPath = System.getProperty('user.home') + File.separator + 'blackduck'
+            detectProperties.outputPath = System.getProperty('user.home') + File.separator + 'blackduck'
         }
 
-        detectProperties.nugetInspectorPackageName = detectProperties.nugetInspectorPackageName.trim()
-        detectProperties.nugetInspectorPackageVersion = detectProperties.nugetInspectorPackageVersion.trim()
+        detectProperties.nugetInspectorName = detectProperties.nugetInspectorName.trim()
+        detectProperties.nugetInspectorName = detectProperties.nugetInspectorName.trim()
 
-        outputDirectory = new File(detectProperties.outputDirectoryPath)
+        outputDirectory = new File(detectProperties.outputPath)
         outputDirectory.mkdirs()
         if (!outputDirectory.exists() || !outputDirectory.isDirectory()) {
-            throw new DetectException("The output directory ${detectProperties.outputDirectoryPath} does not exist. The system property 'user.home' will be used by default, but the output directory must exist.")
+            throw new DetectException("The output directory ${detectProperties.outputPath} does not exist. The system property 'user.home' will be used by default, but the output directory must exist.")
         }
-        detectProperties.outputDirectoryPath = detectProperties.outputDirectoryPath.trim()
+        detectProperties.outputPath = detectProperties.outputPath.trim()
 
         MutablePropertySources mutablePropertySources = configurableEnvironment.getPropertySources()
         mutablePropertySources.each { propertySource ->
@@ -225,13 +225,13 @@ class DetectConfiguration {
         return BooleanUtils.toBoolean(detectProperties.hubOfflineMode)
     }
     public boolean getHubAutoImportCertificate() {
-        return BooleanUtils.toBoolean(detectProperties.hubAutoImportCertificate)
+        return BooleanUtils.toBoolean(detectProperties.hubAutoImportCert)
     }
     public String getSourcePath() {
         return detectProperties.sourcePath
     }
-    public String getOutputDirectoryPath() {
-        return detectProperties.outputDirectoryPath
+    public String getoutputPath() {
+        return detectProperties.outputPath
     }
     public int getSearchDepth() {
         return convertInt(detectProperties.searchDepth)
@@ -249,10 +249,10 @@ class DetectConfiguration {
         return detectProperties.projectVersionName?.trim()
     }
     public String getProjectCodeLocationPrefix() {
-        return detectProperties.projectCodeLocationPrefix?.trim()
+        return detectProperties.projectCodelocationPrefix?.trim()
     }
     public boolean getProjectLevelMatchAdjustments() {
-        return BooleanUtils.toBoolean(detectProperties.projectLevelMatchAdjustments)
+        return BooleanUtils.toBoolean(detectProperties.projectLevelAdjustments)
     }
     public String getProjectVersionPhase() {
         return detectProperties.projectVersionPhase?.trim()
@@ -273,31 +273,31 @@ class DetectConfiguration {
         return detectProperties.gradleBuildCommand
     }
     public String getGradleExcludedConfigurationNames() {
-        return detectProperties.gradleExcludedConfigurationNames
+        return detectProperties.gradleExcludedConfigurations
     }
     public String getGradleIncludedConfigurationNames() {
-        return detectProperties.gradleIncludedConfigurationNames
+        return detectProperties.gradleIncludedConfigurations
     }
     public String getGradleExcludedProjectNames() {
-        return detectProperties.gradleExcludedProjectNames
+        return detectProperties.gradleExcludedProjects
     }
     public String getGradleIncludedProjectNames() {
-        return detectProperties.gradleIncludedProjectNames
+        return detectProperties.gradleIncludedProjects
     }
     public boolean getGradleCleanupBuildBlackduckDirectory() {
         return BooleanUtils.toBoolean(detectProperties.gradleCleanupBuildBlackduckDirectory)
     }
     public String getNugetInspectorPackageName() {
-        return detectProperties.nugetInspectorPackageName
+        return detectProperties.nugetInspectorName
     }
     public String getNugetInspectorPackageVersion() {
-        return detectProperties.nugetInspectorPackageVersion
+        return detectProperties.nugetInspectorVersion
     }
     public String getNugetInspectorExcludedModules() {
-        return detectProperties.nugetInspectorExcludedModules
+        return detectProperties.nugetExcludedModules
     }
     public boolean getNugetInspectorIgnoreFailure() {
-        return BooleanUtils.toBoolean(detectProperties.nugetInspectorIgnoreFailure)
+        return BooleanUtils.toBoolean(detectProperties.nugetIgnoreFailure)
     }
     public String getMavenScope() {
         return detectProperties.mavenScope
@@ -324,7 +324,7 @@ class DetectConfiguration {
         return detectProperties.pipProjectName
     }
     public boolean getPipThreeOverride() {
-        return BooleanUtils.toBoolean(detectProperties.pipThreeOverride)
+        return BooleanUtils.toBoolean(detectProperties.pipPip3)
     }
     public String getPythonPath() {
         return detectProperties.pythonPath
@@ -333,10 +333,10 @@ class DetectConfiguration {
         return detectProperties.pipPath
     }
     public String getVirtualEnvPath() {
-        return detectProperties.virtualEnvPath
+        return detectProperties.pipVirtualEnvPath
     }
     public String getRequirementsFilePath() {
-        return detectProperties.requirementsFilePath
+        return detectProperties.pipRequirementsPath
     }
     public String getGoDepPath() {
         return detectProperties.goDepPath
@@ -360,7 +360,7 @@ class DetectConfiguration {
         return detectProperties.bashPath
     }
     public String getLoggingLevel() {
-        return detectProperties.loggingLevel
+        return detectProperties.levelComBlackducksoftwareIntegration
     }
     public boolean getCleanupBomToolFiles() {
         return BooleanUtils.toBoolean(detectProperties.cleanupBomToolFiles)
@@ -402,10 +402,10 @@ class DetectConfiguration {
         return detectProperties.cpanmPath?.trim()
     }
     public String getSbtExcludedConfigurationNames() {
-        return detectProperties.sbtExcludedConfigurationNames
+        return detectProperties.sbtExcludedConfigurations
     }
     public String getSbtIncludedConfigurationNames() {
-        return detectProperties.sbtIncludedConfigurationNames
+        return detectProperties.sbtIncludedConfigurations
     }
     public String getDefaultProjectVersionScheme() {
         return detectProperties.defaultProjectVersionScheme?.trim()
@@ -417,7 +417,7 @@ class DetectConfiguration {
         return detectProperties.defaultProjectVersionTimeformat?.trim()
     }
     public String getAggregateBomName() {
-        return detectProperties.aggregateBomName?.trim()
+        return detectProperties.bomAggregateName?.trim()
     }
     public String getCondaPath() {
         return detectProperties.condaPath?.trim()
@@ -429,13 +429,13 @@ class DetectConfiguration {
         return detectProperties.riskReportPdf
     }
     public String getRiskReportPdfOutputDirectory() {
-        return detectProperties.riskReportPdfOutputDirectory
+        return detectProperties.riskReportPdfPath
     }
     public Boolean getNoticesReport() {
         return detectProperties.noticesReport
     }
     public String getNoticesReportOutputDirectory() {
-        return detectProperties.noticesReportOutputDirectory
+        return detectProperties.noticesReportPath
     }
     public String getGradleInspectorAirGapPath() {
         return detectProperties.gradleInspectorAirGapPath?.trim()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -29,9 +29,13 @@ import com.blackducksoftware.integration.hub.detect.help.ValueDescription
 
 import groovy.transform.TypeChecked
 
+/**
+ * THIS IS A GENERATED FILE. DO NOT MODIFY
+ */
 @Component
 @TypeChecked
 class DetectProperties {
+    private static final String GROUP_PROJECT_INFO = 'project info'
     private static final String GROUP_HUB_CONFIGURATION = 'hub configuration'
     private static final String GROUP_LOGGING = 'logging'
     private static final String GROUP_CLEANUP = 'cleanup'
@@ -46,348 +50,370 @@ class DetectProperties {
     private static final String GROUP_NPM = 'npm'
     private static final String GROUP_NUGET = 'nuget'
     private static final String GROUP_PACKAGIST = 'packagist'
-    private static final String GROUP_PEAR = 'pear' 
+    private static final String GROUP_PEAR = 'pear'
     private static final String GROUP_PIP = 'pip'
     private static final String GROUP_POLICY_CHECK = 'policy check'
-    private static final String GROUP_PROJECT_INFO = 'project info'
-    private static final String GROUP_PYTHON = 'python'
     private static final String GROUP_SBT = 'sbt'
-    private static final String GROUP_SIGNATURE_SCANNER = 'signature scanner'
+    private static final String GROUP_SIGNITURE_SCANNER = 'signiture scanner'
 
-    @ValueDescription(description="If true, the default behavior of printing your configuration properties at startup will be suppressed.", defaultValue="false", group=DetectProperties.GROUP_LOGGING)
-    @Value('${detect.suppress.configuration.output}')
-    Boolean suppressConfigurationOutput
+    //////////////////////// GROUP_PROJECT_INFO ////////////////////////
+    @ValueDescription(description='If set, this will aggregate all the BOMs to create a single BDIO file with the name provided. For Co-Pilot use only', defaultValue='', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.bom.aggregate.name)}')
+    String bomAggregateName
 
-    @ValueDescription(description="If true the bdio files will be deleted after upload", defaultValue="true", group=DetectProperties.GROUP_CLEANUP)
-    @Value('${detect.cleanup.bdio.files}')
-    Boolean cleanupBdioFiles
-
-    @ValueDescription(description="URL of the Hub server", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.url}')
-    String hubUrl
-
-    @ValueDescription(description="Time to wait for rest connections to complete", defaultValue="120", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.timeout}')
-    Integer hubTimeout
-
-    @ValueDescription(description="Hub username", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.username}')
-    String hubUsername
-
-    @ValueDescription(description="Hub password", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.password}')
-    String hubPassword
-
-    @ValueDescription(description="Proxy host", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.proxy.host}')
-    String hubProxyHost
-
-    @ValueDescription(description="Proxy port", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.proxy.port}')
-    String hubProxyPort
-
-    @ValueDescription(description="Proxy username", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.proxy.username}')
-    String hubProxyUsername
-
-    @ValueDescription(description="Proxy password", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.proxy.password}')
-    String hubProxyPassword
-
-    @ValueDescription(description="If true the Hub https certificate will be automatically imported", defaultValue="false", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.auto.import.cert}')
-    Boolean hubAutoImportCertificate
-
-    @ValueDescription(description="This can disable any Hub communication - if true, Detect will not upload BDIO files, it will not check policies, and it will not download and install the signature scanner.", defaultValue="false", group=DetectProperties.GROUP_HUB_CONFIGURATION)
-    @Value('${blackduck.hub.offline.mode}')
-    Boolean hubOfflineMode
-
-    @ValueDescription(description = "Source path to inspect", group=DetectProperties.GROUP_PATHS)
-    @Value('${detect.source.path}')
-    String sourcePath
-
-    @ValueDescription(description = "Output path", group=DetectProperties.GROUP_PATHS)
-    @Value('${detect.output.path}')
-    String outputDirectoryPath
-
-    @ValueDescription(description = "Depth from source paths to search for files.", defaultValue="3", group=DetectProperties.GROUP_PATHS)
-    @Value('${detect.search.depth}')
-    Integer searchDepth
-
-    @ValueDescription(description = "By default, all tools will be included. If you want to exclude specific tools, specify the ones to exclude here. Exclusion rules always win.", group=DetectProperties.GROUP_BOMTOOL)
-    @Value('${detect.excluded.bom.tool.types}')
-    String excludedBomToolTypes
-
-    @ValueDescription(description = "By default, all tools will be included. If you want to include only specific tools, specify the ones to include here. Exclusion rules always win.", group=DetectProperties.GROUP_BOMTOOL)
-    @Value('${detect.included.bom.tool.types}')
-    String includedBomToolTypes
-
-    @ValueDescription(description = "An override for the name to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable project name. If that fails, the final part of the directory path where the inspection is taking place will be used.", group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.name}')
+    @ValueDescription(description='An override for the name to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable project name. If that fails, the final part of the directory path where the inspection is taking place will be used', defaultValue='', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.name)}')
     String projectName
 
-    @ValueDescription(description = "An override for the version to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable version name. If that fails, the current date will be used.", group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.version.name}')
+    @ValueDescription(description='An override for the Project level matches', defaultValue='true', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.level.adjustments)}')
+    Boolean projectLevelAdjustments
+
+    @ValueDescription(description='An override for the version to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable version name. If that fails, the current date will be used', defaultValue='', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.version.name)}')
     String projectVersionName
 
-    @ValueDescription(description = "A prefix to the name of the codelocations created by Detect. Useful for running against the same projects on multiple machines.", defaultValue='', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.codelocation.prefix}')
-    String projectCodeLocationPrefix
-
-    @ValueDescription(description = "An override for the Project level matches.", defaultValue="true", group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.level.adjustments}')
-    String projectLevelMatchAdjustments
-
-    @ValueDescription(description = "An override for the Project Version phase.", defaultValue="Development",  group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.version.phase}')
+    @ValueDescription(description='An override for the Project Version phase', defaultValue='Development', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.version.phase)}')
     String projectVersionPhase
 
-    @ValueDescription(description = "An override for the Project Version distribution", defaultValue="External",  group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.project.version.distribution}')
+    @ValueDescription(description='An override for the Project Version distribution', defaultValue='External', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.version.distribution)}')
     String projectVersionDistribution
 
-    @ValueDescription(description = "Set to true if you would like a policy check from the hub for your project. False by default", defaultValue="false", group=DetectProperties.GROUP_POLICY_CHECK)
-    @Value('${detect.policy.check}')
-    Boolean policyCheck
+    @ValueDescription(description='A prefix to the name of the codelocations created by Detect. Useful for running against the same projects on multiple machines', defaultValue='', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.project.codelocation.prefix)}')
+    String projectCodelocationPrefix
 
-    @ValueDescription(description="Timeout for the Hub's policy check response. When changing this value, keep in mind the checking of policies might have to wait for a new scan to process which can take some time.", defaultValue="300000", group=DetectProperties.GROUP_POLICY_CHECK)
-    @Value('${detect.policy.check.timeout}')
-    Long policyCheckTimeout
-
-    @ValueDescription(description="Version of the Gradle Inspector", defaultValue="0.2.1", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.inspector.version}')
-    String gradleInspectorVersion
-
-    @ValueDescription(description="Gradle build command", defaultValue="dependencies", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.build.command}')
-    String gradleBuildCommand
-
-    @ValueDescription(description="The names of the dependency configurations to exclude", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.excluded.configurations}')
-    String gradleExcludedConfigurationNames
-
-    @ValueDescription( description="The names of the dependency configurations to include", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.included.configurations}')
-    String gradleIncludedConfigurationNames
-
-    @ValueDescription(description="The names of the projects to exclude", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.excluded.projects}')
-    String gradleExcludedProjectNames
-
-    @ValueDescription(description="The names of the projects to include", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.included.projects}')
-    String gradleIncludedProjectNames
-
-    @ValueDescription(description="Set this to false if you do not want the 'blackduck' directory in your build directory to be deleted.", defaultValue="true", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.cleanup.build.blackduck.directory}')
-    Boolean gradleCleanupBuildBlackduckDirectory
-
-    @ValueDescription(description="Name of the Nuget Inspector", defaultValue="IntegrationNugetInspector", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.inspector.name}')
-    String nugetInspectorPackageName
-
-    @ValueDescription(description="Version of the Nuget Inspector", defaultValue="2.0.0", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.inspector.version}')
-    String nugetInspectorPackageVersion
-
-    @ValueDescription(description="The names of the projects in a solution to exclude", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.excluded.modules}')
-    String nugetInspectorExcludedModules
-
-    @ValueDescription(description="If true errors will be logged and then ignored.", defaultValue="false", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.ignore.failure}')
-    Boolean nugetInspectorIgnoreFailure
-
-    @ValueDescription(description="The name of the dependency scope to include", group=DetectProperties.GROUP_MAVEN)
-    @Value('${detect.maven.scope}')
-    String mavenScope
-
-    @ValueDescription(description="Path of the Gradle executable", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.path}')
-    String gradlePath
-
-    @ValueDescription(description="The path of the Maven executable", group=DetectProperties.GROUP_MAVEN)
-    @Value('${detect.maven.path}')
-    String mavenPath
-
-    @ValueDescription(description="The path of the Nuget executable", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.path}')
-    String nugetPath
-
-    @ValueDescription(description="Override for pip inspector to find your project", group=DetectProperties.GROUP_PIP)
-    @Value('${detect.pip.project.name}')
-    String pipProjectName
-
-    @ValueDescription(description="If true will use pip3 if available on class path", defaultValue="false", group=DetectProperties.GROUP_PIP)
-    @Value('${detect.pip.pip3}')
-    Boolean pipThreeOverride
-
-    @ValueDescription(description="The path of the Python executable", group=DetectProperties.GROUP_PYTHON)
-    @Value('${detect.python.path}')
-    String pythonPath
-
-    @ValueDescription(description="The path of the Pip executable", group=DetectProperties.GROUP_PIP)
-    @Value('${detect.pip.path}')
-    String pipPath
-
-    @ValueDescription(description="The path of the Npm executable", group=DetectProperties.GROUP_NPM)
-    @Value('${detect.npm.path}')
-    String npmPath
-
-    @ValueDescription(description="The path of the pear executable", group=DetectProperties.GROUP_PEAR)
-    @Value('${detect.pear.path}')
-    String pearPath
-
-    @ValueDescription(description="Set to true if you would like to include the not required packages", defaultValue='false', group=DetectProperties.GROUP_PEAR)
-    @Value('${detect.pear.not.required.dependencies}')
-    Boolean pearNotRequiredDependencies
-
-    @ValueDescription(description="The path to a user's virtual environment", group=DetectProperties.GROUP_PIP)
-    @Value('${detect.pip.virtualEnv.path}')
-    String virtualEnvPath
-
-    @ValueDescription(description="The path of the requirements.txt file", group=DetectProperties.GROUP_PIP)
-    @Value('${detect.pip.requirements.path}')
-    String requirementsFilePath
-
-    @ValueDescription(description="Path of the Go Dep executable", group=DetectProperties.GROUP_GO)
-    @Value('${detect.go.dep.path}')
-    String goDepPath
-
-    @ValueDescription(description="Path of the docker executable", group=DetectProperties.GROUP_DOCKER)
-    @Value('${detect.docker.path}')
-    String dockerPath
-
-    @ValueDescription(description="This is used to override using the hosted script by github url. You can provide your own script at this path.", group=DetectProperties.GROUP_DOCKER)
-    @Value('${detect.docker.inspector.path}')
-    String dockerInspectorPath
-
-    @ValueDescription(description="Version of the Hub Docker Inspector to use", defaultValue="latest", group=DetectProperties.GROUP_DOCKER)
-    @Value('${detect.docker.inspector.version}')
-    String dockerInspectorVersion
-
-    @ValueDescription(description="A saved docker image - must be a .tar file. For detect to run docker either this property or detect.docker.image must be set.", group=DetectProperties.GROUP_DOCKER)
-    @Value('${detect.docker.tar}')
-    String dockerTar
-
-    @ValueDescription(description="The docker image name to inspect. For detect to run docker either this property or detect.docker.tar must be set.", group=DetectProperties.GROUP_DOCKER)
-    @Value('${detect.docker.image}')
-    String dockerImage
-
-    @ValueDescription(description="Path of the bash executable", group=DetectProperties.GROUP_PATHS)
-    @Value('${detect.bash.path}')
-    String bashPath
-
-    @ValueDescription(description="The logging level of Detect (ALL|TRACE|DEBUG|INFO|WARN|ERROR|FATAL|OFF)", defaultValue='INFO', group=DetectProperties.GROUP_LOGGING)
-    @Value('${logging.level.com.blackducksoftware.integration}')
-    String loggingLevel
-
-    @ValueDescription(description="Detect creates temporary files in the output directory. If set to true this will clean them up after execution", defaultValue='true', group=DetectProperties.GROUP_CLEANUP)
-    @Value('${detect.cleanup.bom.tool.files}')
-    Boolean cleanupBomToolFiles
-
-    @ValueDescription(description="If set to true, the signature scanner results will not be uploaded to the Hub and the scanner results will be written to disk.", defaultValue='false', group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.dry.run}')
-    Boolean hubSignatureScannerDryRun
-
-    @ValueDescription(description="Enables you to specify sub-directories to exclude from scans", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.exclusion.patterns}')
-    String[] hubSignatureScannerExclusionPatterns
-
-    @ValueDescription(description="These paths and only these paths will be scanned.", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.paths}')
-    String[] hubSignatureScannerPaths
-
-    @ValueDescription(description="The relative paths of directories to be excluded from scan registration", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.relative.paths.to.exclude}')
-    String[] hubSignatureScannerRelativePathsToExclude
-
-    @ValueDescription(description="The memory for the scanner to use.", defaultValue="4096", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.memory}')
-    Integer hubSignatureScannerMemory
-
-    @ValueDescription(description="Set to true to disable the Hub Signature Scanner.", defaultValue="false", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.disabled}')
-    Boolean hubSignatureScannerDisabled
-
-    @ValueDescription(description="To use a local signature scanner, set its location with this property. This will be the path that contains the 'Hub_Scan_Installation' directory where the signature scanner was unzipped.", group=DetectProperties.GROUP_SIGNATURE_SCANNER)
-    @Value('${detect.hub.signature.scanner.offline.local.path}')
-    String hubSignatureScannerOfflineLocalPath
-
-    @ValueDescription(description="Set this value to false if you would like to exclude your dev requires dependencies when ran", defaultValue='true', group=DetectProperties.GROUP_PACKAGIST)
-    @Value('${detect.packagist.include.dev.dependencies}')
-    Boolean packagistIncludeDevDependencies
-
-    @ValueDescription(description="The path of the perl executable", group=DetectProperties.GROUP_CPAN)
-    @Value('${detect.perl.path}')
-    String perlPath
-
-    @ValueDescription(description="The path of the cpan executable", group=DetectProperties.GROUP_CPAN)
-    @Value('${detect.cpan.path}')
-    String cpanPath
-
-    @ValueDescription(description="The path of the cpanm executable", group=DetectProperties.GROUP_CPAN)
-    @Value('${detect.cpanm.path}')
-    String cpanmPath
-
-    @ValueDescription(description="The names of the sbt configurations to exclude", group=DetectProperties.GROUP_SBT)
-    @Value('${detect.sbt.excluded.configurations}')
-    String sbtExcludedConfigurationNames
-
-    @ValueDescription( description="The names of the sbt configurations to include", group=DetectProperties.GROUP_SBT)
-    @Value('${detect.sbt.included.configurations}')
-    String sbtIncludedConfigurationNames
-
-    @ValueDescription(description="The scheme to use when the package managers can not determine a version, either 'text' or 'timestamp'", defaultValue='text', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.default.project.version.scheme}')
+    @ValueDescription(description='The scheme to use when the package managers can not determine a version, either &#39;text&#39; or &#39;timestamp&#39;', defaultValue='text', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.default.project.version.scheme)}')
     String defaultProjectVersionScheme
 
-    @ValueDescription(description="The text to use as the default project version", defaultValue='Detect Unknown Version', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.default.project.version.text}')
+    @ValueDescription(description='The text to use as the default project version', defaultValue='Detect Unkown Version', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.default.project.version.text)}')
     String defaultProjectVersionText
 
-    @ValueDescription(description="The timestamp format to use as the default project version", defaultValue='yyyy-MM-dd\'T\'HH:mm:ss.SSS', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.default.project.version.timeformat}')
+    @ValueDescription(description='The timestamp format to use as the default project version', defaultValue='yyyy-MM-dd&#39;T&#39;HH:mm:ss.SSS', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.default.project.version.timeformat)}')
     String defaultProjectVersionTimeformat
 
-    @ValueDescription(description="If set, this will aggregate all the BOMs to create a single BDIO file with the name provided. For Co-Pilot use only", group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.bom.aggregate.name}')
-    String aggregateBomName
-
-    @ValueDescription (description="When set to true, a Black Duck risk report in PDF form will be created", defaultValue='false', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.risk.report.pdf}')
+    @ValueDescription(description='When set to true, a Black Duck risk report in PDF form will be created', defaultValue='false', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.risk.report.pdf)}')
     Boolean riskReportPdf
 
-    @ValueDescription (description="The output directory for risk report in PDF. Default is the source directory", defaultValue='.', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.risk.report.pdf.path}')
-    String riskReportPdfOutputDirectory
+    @ValueDescription(description='The output directory for risk report in PDF. Default is the source directory', defaultValue='.', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.risk.report.pdf.path)}')
+    String riskReportPdfPath
 
-    @ValueDescription (description="When set to true, a Black Duck notices report in text form will be created in your source directory", defaultValue='false', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.notices.report}')
+    @ValueDescription(description='When set to true, a Black Duck notices report in text form will be created in your source directory', defaultValue='false', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.notices.report)}')
     Boolean noticesReport
 
-    @ValueDescription (description="The output directory for notices report. Default is the source directory", defaultValue='.', group=DetectProperties.GROUP_PROJECT_INFO)
-    @Value('${detect.notices.report.path}')
-    String noticesReportOutputDirectory
+    @ValueDescription(description='The output directory for notices report. Default is the source directory', defaultValue='.', group=DetectProperties.GROUP_PROJECT_INFO)
+    @Value('${(detect.notices.report.path)}')
+    String noticesReportPath
 
-    @ValueDescription(description="The path of the conda executable", group=DetectProperties.GROUP_CONDA)
-    @Value('${detect.conda.path}')
+    //////////////////////// GROUP_HUB_CONFIGURATION ////////////////////////
+    @ValueDescription(description='URL of the Hub server', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.url)}')
+    String hubUrl
+
+    @ValueDescription(description='Time to wait for rest connections to complete', defaultValue='120', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.timeout)}')
+    Integer hubTimeout
+
+    @ValueDescription(description='Hub username', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.username)}')
+    String hubUsername
+
+    @ValueDescription(description='Hub password', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.password)}')
+    String hubPassword
+
+    @ValueDescription(description='If true the Hub https certificate will be automatically imported', defaultValue='false', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.auto.import.cert)}')
+    Boolean hubAutoImportCert
+
+    @ValueDescription(description='This can disable any Hub communication - if true, Detect will not upload BDIO files, it will not check policies, and it will not download and install the signature scanner', defaultValue='false', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.offline.mode)}')
+    Boolean hubOfflineMode
+
+    @ValueDescription(description='Proxy host', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.proxy.host)}')
+    String hubProxyHost
+
+    @ValueDescription(description='Proxy port', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.proxy.port)}')
+    String hubProxyPort
+
+    @ValueDescription(description='Proxy username', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.proxy.username)}')
+    String hubProxyUsername
+
+    @ValueDescription(description='Project password', defaultValue='', group=DetectProperties.GROUP_HUB_CONFIGURATION)
+    @Value('${(blackduck.hub.proxy.password)}')
+    String hubProxyPassword
+
+    //////////////////////// GROUP_LOGGING ////////////////////////
+    @ValueDescription(description='If true, the default behavior of printing your configuration properties at startup will be suppressed', defaultValue='false', group=DetectProperties.GROUP_LOGGING)
+    @Value('${(detect.suppress.configuration.output)}')
+    Boolean suppressConfigurationOutput
+
+    @ValueDescription(description='The logging level of Detect (ALL|TRACE|DEBUG|INFO|WARN|ERROR|FATAL|OFF)', defaultValue='INFO', group=DetectProperties.GROUP_LOGGING)
+    @Value('${(logging.level.com.blackducksoftware.integration)}')
+    String levelComBlackducksoftwareIntegration
+
+    @ValueDescription(description='The logging level to run Detect at', defaultValue='${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}', group=DetectProperties.GROUP_LOGGING)
+    @Value('${(logging.pattern.console)}')
+    String patternConsole
+
+    //////////////////////// GROUP_CLEANUP ////////////////////////
+    @ValueDescription(description='Detect creates temporary files in the output directory. If set to true this will clean them up after execution', defaultValue='true', group=DetectProperties.GROUP_CLEANUP)
+    @Value('${(detect.cleanup.bom.tool.files)}')
+    Boolean cleanupBomToolFiles
+
+    @ValueDescription(description='If true the bdio files will be deleted after upload', defaultValue='true', group=DetectProperties.GROUP_CLEANUP)
+    @Value('${(detect.cleanup.bdio.files)}')
+    Boolean cleanupBdioFiles
+
+    //////////////////////// GROUP_PATHS ////////////////////////
+    @ValueDescription(description='Source path to inspect', defaultValue='', group=DetectProperties.GROUP_PATHS)
+    @Value('${(detect.source.path)}')
+    String sourcePath
+
+    @ValueDescription(description='Output path', defaultValue='', group=DetectProperties.GROUP_PATHS)
+    @Value('${(detect.output.path)}')
+    String outputPath
+
+    @ValueDescription(description='Depth from source paths to search for files.', defaultValue='3', group=DetectProperties.GROUP_PATHS)
+    @Value('${(detect.search.depth)}')
+    Integer searchDepth
+
+    @ValueDescription(description='Path of the bash executable', defaultValue='', group=DetectProperties.GROUP_PATHS)
+    @Value('${(detect.bash.path)}')
+    String bashPath
+
+    //////////////////////// GROUP_BOMTOOL ////////////////////////
+    @ValueDescription(description='By default, all tools will be included. If you want to exclude specific tools, specify the ones to exclude here. Exclusion rules always win.', defaultValue='', group=DetectProperties.GROUP_BOMTOOL)
+    @Value('${(detect.excluded.bom.tool.types)}')
+    String excludedBomToolTypes
+
+    @ValueDescription(description='By default, all tools will be included. If you want to include only specific tools, specify the ones to include here. Exclusion rules always win.', defaultValue='', group=DetectProperties.GROUP_BOMTOOL)
+    @Value('${(detect.included.bom.tool.types)}')
+    String includedBomToolTypes
+
+    //////////////////////// GROUP_CONDA ////////////////////////
+    @ValueDescription(description='The path to the conda executable', defaultValue='', group=DetectProperties.GROUP_CONDA)
+    @Value('${(detect.conda.path)}')
     String condaPath
 
-    @ValueDescription(description="The name of the anaconda environment used by your project", group=DetectProperties.GROUP_CONDA)
-    @Value('${detect.conda.environment.name}')
+    @ValueDescription(description='The name of the anaconda environment used by your project', defaultValue='', group=DetectProperties.GROUP_CONDA)
+    @Value('${(detect.conda.environment.name)}')
     String condaEnvironmentName
 
-    @ValueDescription(description="The path to the directory containing the air gap dependencies for the gradle inspector", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.inspector.air.gap.path}')
+    //////////////////////// GROUP_CPAN ////////////////////////
+    @ValueDescription(description='The path to the cpan executable', defaultValue='', group=DetectProperties.GROUP_CPAN)
+    @Value('${(detect.cpan.path)}')
+    String cpanPath
+
+    @ValueDescription(description='The path to the cpanm executable', defaultValue='', group=DetectProperties.GROUP_CPAN)
+    @Value('${(detect.cpanm.path)}')
+    String cpanmPath
+
+    @ValueDescription(description='The path to the perl executable', defaultValue='', group=DetectProperties.GROUP_CPAN)
+    @Value('${(detect.perl.path)}')
+    String perlPath
+
+    //////////////////////// GROUP_DOCKER ////////////////////////
+    @ValueDescription(description='This is used to override using the hosted script by github url. You can provide your own script at this path', defaultValue='', group=DetectProperties.GROUP_DOCKER)
+    @Value('${(detect.docker.inspector.path)}')
+    String dockerInspectorPath
+
+    @ValueDescription(description='Version of the Hub Docker Inspector to use', defaultValue='latest', group=DetectProperties.GROUP_DOCKER)
+    @Value('${(detect.docker.inspector.version)}')
+    String dockerInspectorVersion
+
+    @ValueDescription(description='A saved docker image - must be a .tar file. For detect to run docker either this property or detect.docker.image must be set', defaultValue='', group=DetectProperties.GROUP_DOCKER)
+    @Value('${(detect.docker.tar)}')
+    String dockerTar
+
+    @ValueDescription(description='The docker image name to inspect. For detect to run docker either this property or detect.docker.tar must be set', defaultValue='', group=DetectProperties.GROUP_DOCKER)
+    @Value('${(detect.docker.image)}')
+    String dockerImage
+
+    @ValueDescription(description='The path to the docker executable', defaultValue='', group=DetectProperties.GROUP_DOCKER)
+    @Value('${(detect.docker.path)}')
+    String dockerPath
+
+    //////////////////////// GROUP_GO ////////////////////////
+    @ValueDescription(description='The path to the Go Dep executable', defaultValue='', group=DetectProperties.GROUP_GO)
+    @Value('${(detect.go.dep.path)}')
+    String goDepPath
+
+    //////////////////////// GROUP_GRADLE ////////////////////////
+    @ValueDescription(description='Version of the Gradle Inspector', defaultValue='0.2.1', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.inspector.version)}')
+    String gradleInspectorVersion
+
+    @ValueDescription(description='The path to the directory containing the air gap dependencies for the gradle inspector', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.inspector.air.gap.path)}')
     String gradleInspectorAirGapPath
 
-    @ValueDescription(description="The path to the nuget inspector nupkg", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.inspector.air.gap.path}')
+    @ValueDescription(description='The path to the Gradle executable', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.path)}')
+    String gradlePath
+
+    @ValueDescription(description='Gradle build command', defaultValue='dependencies', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.build.command)}')
+    String gradleBuildCommand
+
+    @ValueDescription(description='The names of the dependency configurations to exclude', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.excluded.configurations)}')
+    String gradleExcludedConfigurations
+
+    @ValueDescription(description='The names of the dependency configurations to include', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.included.configurations)}')
+    String gradleIncludedConfigurations
+
+    @ValueDescription(description='The names of the projects to exclude', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.excluded.projects)}')
+    String gradleExcludedProjects
+
+    @ValueDescription(description='The names of the projects to include', defaultValue='', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.included.projects)}')
+    String gradleIncludedProjects
+
+    @ValueDescription(description='Set this to false if you do not want the &#39;blackduck&#39; directory in your build directory to be deleted', defaultValue='true', group=DetectProperties.GROUP_GRADLE)
+    @Value('${(detect.gradle.cleanup.build.blackduck.directory)}')
+    Boolean gradleCleanupBuildBlackduckDirectory
+
+    //////////////////////// GROUP_MAVEN ////////////////////////
+    @ValueDescription(description='The name of the dependency scope to include', defaultValue='', group=DetectProperties.GROUP_MAVEN)
+    @Value('${(detect.maven.scope)}')
+    String mavenScope
+
+    @ValueDescription(description='The path to the Maven executable', defaultValue='', group=DetectProperties.GROUP_MAVEN)
+    @Value('${(detect.maven.path)}')
+    String mavenPath
+
+    //////////////////////// GROUP_NPM ////////////////////////
+    @ValueDescription(description='The path to the Npm executable', defaultValue='', group=DetectProperties.GROUP_NPM)
+    @Value('${(detect.npm.path)}')
+    String npmPath
+
+    //////////////////////// GROUP_NUGET ////////////////////////
+    @ValueDescription(description='Name of the Nuget Inspector', defaultValue='IntegrationNugetInspector', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.inspector.name)}')
+    String nugetInspectorName
+
+    @ValueDescription(description='Version of the Nuget Inspector', defaultValue='2.0.0', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.inspector.version)}')
+    String nugetInspectorVersion
+
+    @ValueDescription(description='The path to the nuget inspector nupkg file', defaultValue='', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.inspector.air.gap.path)}')
     String nugetInspectorAirGapPath
 
-    @ValueDescription(description="The source for nuget packages", defaultValue='https://www.nuget.org/api/v2/', group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.packages.repo.url}')
+    @ValueDescription(description='The source for nuget packages', defaultValue='https://www.nuget.org/api/v2/', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.packages.repo.url)}')
     String nugetPackagesRepoUrl
-}
 
+    @ValueDescription(description='If true errors will be logged and then ignored', defaultValue='false', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.ignore.failure)}')
+    Boolean nugetIgnoreFailure
+
+    @ValueDescription(description='The names of the projects in a solution to exclude', defaultValue='', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.excluded.modules)}')
+    String nugetExcludedModules
+
+    @ValueDescription(description='The path to the Nuget executable', defaultValue='', group=DetectProperties.GROUP_NUGET)
+    @Value('${(detect.nuget.path)}')
+    String nugetPath
+
+    //////////////////////// GROUP_PACKAGIST ////////////////////////
+    @ValueDescription(description='Set this value to false if you would like to exclude your dev requires dependencies when ran', defaultValue='true', group=DetectProperties.GROUP_PACKAGIST)
+    @Value('${(detect.packagist.include.dev.dependencies)}')
+    Boolean packagistIncludeDevDependencies
+
+    //////////////////////// GROUP_PEAR ////////////////////////
+    @ValueDescription(description='The path to the Pear executable', defaultValue='', group=DetectProperties.GROUP_PEAR)
+    @Value('${(detect.pear.path)}')
+    String pearPath
+
+    @ValueDescription(description='Set to true if you would like to include the packages that are not required', defaultValue='false', group=DetectProperties.GROUP_PEAR)
+    @Value('${(detect.pear.not.required.dependencies)}')
+    Boolean pearNotRequiredDependencies
+
+    //////////////////////// GROUP_PIP ////////////////////////
+    @ValueDescription(description='The path to the python executable', defaultValue='', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.python.path)}')
+    String pythonPath
+
+    @ValueDescription(description='The path to the pip executable', defaultValue='', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.pip.path)}')
+    String pipPath
+
+    @ValueDescription(description='Override for pip inspector to find your project', defaultValue='', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.pip.project.name)}')
+    String pipProjectName
+
+    @ValueDescription(description='If true, detect will use pip3 if available on path', defaultValue='false', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.pip.pip3)}')
+    Boolean pipPip3
+
+    @ValueDescription(description='The path to a requirements file', defaultValue='', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.pip.requirements.path)}')
+    String pipRequirementsPath
+
+    @ValueDescription(description='The path to a user&#39;s virtual environment', defaultValue='', group=DetectProperties.GROUP_PIP)
+    @Value('${(detect.pip.virtualEnv.path)}')
+    String pipVirtualEnvPath
+
+    //////////////////////// GROUP_POLICY_CHECK ////////////////////////
+    @ValueDescription(description='Set to true if you would like a policy check from the hub for your project', defaultValue='false', group=DetectProperties.GROUP_POLICY_CHECK)
+    @Value('${(detect.policy.check)}')
+    Boolean policyCheck
+
+    @ValueDescription(description='Timeout for the Hub&#39;s policy check response. When changing this value, keep in mind the checking of policies might have to wait for a new scan to process which can take some time', defaultValue='300000', group=DetectProperties.GROUP_POLICY_CHECK)
+    @Value('${(detect.policy.check.timeout)}')
+    Long policyCheckTimeout
+
+    //////////////////////// GROUP_SBT ////////////////////////
+    @ValueDescription(description='The names of the sbt configurations to exclude', defaultValue='', group=DetectProperties.GROUP_SBT)
+    @Value('${(detect.sbt.excluded.configurations)}')
+    String sbtExcludedConfigurations
+
+    @ValueDescription(description='The names of the sbt configurations to include', defaultValue='', group=DetectProperties.GROUP_SBT)
+    @Value('${(detect.sbt.included.configurations)}')
+    String sbtIncludedConfigurations
+
+    //////////////////////// GROUP_SIGNITURE_SCANNER ////////////////////////
+    @ValueDescription(description='The relative paths of directories to be excluded from scan registration', defaultValue='', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.relative.paths.to.exclude)}')
+    String[] hubSignatureScannerRelativePathsToExclude
+
+    @ValueDescription(description='Enables you to specify sub-directories to exclude from scans', defaultValue='', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.exclusion.patterns)}')
+    String[] hubSignatureScannerExclusionPatterns
+
+    @ValueDescription(description='These paths and only these paths will be scanned', defaultValue='', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.paths)}')
+    String[] hubSignatureScannerPaths
+
+    @ValueDescription(description='The memory for the scanner to use', defaultValue='4096', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.memory)}')
+    Integer hubSignatureScannerMemory
+
+    @ValueDescription(description='Set to true to disable the Hub Signature Scanner', defaultValue='false', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.disabled)}')
+    Boolean hubSignatureScannerDisabled
+
+    @ValueDescription(description='If set to true, the signature scanner results will not be uploaded to the Hub and the scanner results will be written to disk', defaultValue='false', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.dry.run)}')
+    Boolean hubSignatureScannerDryRun
+
+    @ValueDescription(description='To use a local signature scanner, set its location with this property. This will be the path that contains the &#39;Hub_Scan_Installation&#39; directory where the signature scanner was unzipped', defaultValue='', group=DetectProperties.GROUP_SIGNITURE_SCANNER)
+    @Value('${(detect.hub.signature.scanner.offline.local.path)}')
+    String hubSignatureScannerOfflineLocalPath
+
+}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -46,7 +46,7 @@ class DetectProperties {
     private static final String GROUP_NPM = 'npm'
     private static final String GROUP_NUGET = 'nuget'
     private static final String GROUP_PACKAGIST = 'packagist'
-    private static final String GROUP_PEAR = 'pear'
+    private static final String GROUP_PEAR = 'pear' 
     private static final String GROUP_PIP = 'pip'
     private static final String GROUP_POLICY_CHECK = 'policy check'
     private static final String GROUP_PROJECT_INFO = 'project info'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,42 +1,72 @@
-blackduck.hub.url=
-blackduck.hub.timeout=
-blackduck.hub.username=
-blackduck.hub.password=
+# THIS IS A GENERATED FILE - DO NOT MODIFY
 
-blackduck.hub.auto.import.cert=
-blackduck.hub.offline.mode=
-
-blackduck.hub.proxy.host=
-blackduck.hub.proxy.port=
-blackduck.hub.proxy.username=
-blackduck.hub.proxy.password=
-
-detect.cleanup.bom.tool.files=
-
-detect.source.path=
-detect.output.path=
-detect.search.depth=
-detect.cleanup.bdio.files=
-detect.cleanup.bom.tool.files=
+# project info
 detect.bom.aggregate.name=
-detect.excluded.bom.tool.types=
-detect.included.bom.tool.types=
-detect.suppress.configuration.output=
-
 detect.project.name=
 detect.project.level.adjustments=
 detect.project.version.name=
 detect.project.version.phase=
 detect.project.version.distribution=
 detect.project.codelocation.prefix=
-
 detect.default.project.version.scheme=
 detect.default.project.version.text=
 detect.default.project.version.timeformat=
+detect.risk.report.pdf=
+detect.risk.report.pdf.path=
+detect.notices.report=
+detect.notices.report.path=
 
-detect.policy.check=
-detect.policy.check.timeout=
+# hub configuration
+blackduck.hub.url=
+blackduck.hub.timeout=
+blackduck.hub.username=
+blackduck.hub.password=
+blackduck.hub.auto.import.cert=
+blackduck.hub.offline.mode=
+blackduck.hub.proxy.host=
+blackduck.hub.proxy.port=
+blackduck.hub.proxy.username=
+blackduck.hub.proxy.password=
 
+# logging
+detect.suppress.configuration.output=
+logging.level.com.blackducksoftware.integration=INFO
+logging.pattern.console=${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}
+
+# cleanup
+detect.cleanup.bom.tool.files=
+detect.cleanup.bdio.files=
+
+# paths
+detect.source.path=
+detect.output.path=
+detect.search.depth=
+detect.bash.path=
+
+# bomtool
+detect.excluded.bom.tool.types=
+detect.included.bom.tool.types=
+
+# conda
+detect.conda.path=
+detect.conda.environment.name=
+
+# cpan
+detect.cpan.path=
+detect.cpanm.path=
+detect.perl.path=
+
+# docker
+detect.docker.inspector.path=
+detect.docker.inspector.version=
+detect.docker.tar=
+detect.docker.image=
+detect.docker.path=
+
+# go
+detect.go.dep.path=
+
+# gradle
 detect.gradle.inspector.version=
 detect.gradle.inspector.air.gap.path=
 detect.gradle.path=
@@ -47,16 +77,14 @@ detect.gradle.excluded.projects=
 detect.gradle.included.projects=
 detect.gradle.cleanup.build.blackduck.directory=
 
-detect.pip.project.name=
-detect.pip.pip3=
-detect.pip.requirements.path=
-detect.pip.virtualEnv.path=
-detect.pip.path=
-detect.python.path=
-
+# maven
 detect.maven.scope=
 detect.maven.path=
 
+# npm
+detect.npm.path=
+
+# nuget
 detect.nuget.inspector.name=
 detect.nuget.inspector.version=
 detect.nuget.inspector.air.gap.path=
@@ -65,32 +93,30 @@ detect.nuget.ignore.failure=
 detect.nuget.excluded.modules=
 detect.nuget.path=
 
-detect.go.dep.path=
+# packagist
+detect.packagist.include.dev.dependencies=
 
-detect.docker.inspector.path=
-detect.docker.inspector.version=
-detect.docker.tar=
-detect.docker.image=
-detect.docker.path=
-detect.bash.path=
-
-detect.perl.path=
-detect.cpan.path=
-detect.cpanm.path=
-
-detect.npm.path=
-
+# pear
 detect.pear.path=
 detect.pear.not.required.dependencies=
 
-detect.packagist.include.dev.dependencies=
+# pip
+detect.python.path=
+detect.pip.path=
+detect.pip.project.name=
+detect.pip.pip3=
+detect.pip.requirements.path=
+detect.pip.virtualEnv.path=
 
-detect.conda.path=
-detect.conda.environment.name=
+# policy check
+detect.policy.check=
+detect.policy.check.timeout=
 
+# sbt
 detect.sbt.excluded.configurations=
 detect.sbt.included.configurations=
 
+# signiture scanner
 detect.hub.signature.scanner.relative.paths.to.exclude=
 detect.hub.signature.scanner.exclusion.patterns=
 detect.hub.signature.scanner.paths=
@@ -98,13 +124,3 @@ detect.hub.signature.scanner.memory=
 detect.hub.signature.scanner.disabled=
 detect.hub.signature.scanner.dry.run=
 detect.hub.signature.scanner.offline.local.path=
-
-detect.risk.report.pdf=
-detect.risk.report.pdf.path=
-
-detect.notices.report=
-detect.notices.report.path=
-
-logging.level.com.blackducksoftware.integration=INFO
-
-logging.pattern.console=${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}

--- a/src/main/resources/mustache/DetectProperties.groovy.mustache
+++ b/src/main/resources/mustache/DetectProperties.groovy.mustache
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.detect
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+import com.blackducksoftware.integration.hub.detect.help.ValueDescription
+
+import groovy.transform.TypeChecked
+
+/**
+ * THIS IS A GENERATED FILE. DO NOT MODIFY
+ */
+@Component
+@TypeChecked
+class DetectProperties {
+    {{#groups}}
+    private static final String {{groupVariableName}} = '{{name}}'
+    {{/groups}}
+
+    {{#groups}}
+    //////////////////////// {{groupVariableName}} ////////////////////////
+    {{#properties}}
+    @ValueDescription(description='{{description}}', defaultValue='{{defaultValue}}', group=DetectProperties.{{groupVariableName}})
+    @Value('${({{name}})}')
+    {{type}} {{propertyVariableName}}
+
+    {{/properties}}
+    {{/groups}}
+}

--- a/src/main/resources/mustache/application.properties.mustache
+++ b/src/main/resources/mustache/application.properties.mustache
@@ -1,0 +1,1 @@
+{{scope}}.{{propertyName}}=

--- a/src/main/resources/mustache/application.properties.mustache
+++ b/src/main/resources/mustache/application.properties.mustache
@@ -1,1 +1,9 @@
-{{scope}}.{{propertyName}}=
+
+{{#propertyGroups}}
+    {{#propertyGroup}}
+        # {{groupName}}
+        {{#properties}}
+            {{propertyName}}=
+        {{/properties}}
+    {{/propertyGroup}}
+{{/propertyGroups}}

--- a/src/main/resources/mustache/application.properties.mustache
+++ b/src/main/resources/mustache/application.properties.mustache
@@ -1,9 +1,8 @@
+# THIS IS A GENERATED FILE - DO NOT MODIFY
+{{#groups}}
 
-{{#propertyGroups}}
-    {{#propertyGroup}}
-        # {{groupName}}
-        {{#properties}}
-            {{propertyName}}=
-        {{/properties}}
-    {{/propertyGroup}}
-{{/propertyGroups}}
+# {{name}}
+{{#properties}}
+{{name}}={{value}}
+{{/properties}}
+{{/groups}}

--- a/src/main/resources/mustache/properties.json
+++ b/src/main/resources/mustache/properties.json
@@ -1,0 +1,451 @@
+{
+  "project info": {
+      "detect.bom.aggregate.name": {
+        "description": "If set, this will aggregate all the BOMs to create a single BDIO file with the name provided. For Co-Pilot use only",
+        "defaultValue": "",
+        "type": "String"
+      },
+      "detect.project.name": {
+        "description": "An override for the name to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable project name. If that fails, the final part of the directory path where the inspection is taking place will be used",
+        "defaultValue": "",
+        "type": "String"
+      },
+      "detect.project.level.adjustments": {
+        "description": "An override for the Project level matches",
+        "defaultValue": "true",
+        "defaultValue": "Boolean"
+      },
+      "detect.project.version.name": {
+        "description": "An override for the version to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable version name. If that fails, the current date will be used",
+        "defaultValue": "",
+        "type": "String"
+      },
+      "detect.project.version.phase": {
+        "description": "An override for the Project Version phase",
+        "defaultValue": "Development"
+      },
+      "detect.project.version.distribution": {
+        "description": "An override for the Project Version distribution",
+        "defaultValue": "External"
+      },
+      "detect.project.codelocation.prefix": {
+        "description": "A prefix to the name of the codelocations created by Detect. Useful for running against the same projects on multiple machines",
+        "defaultValue": "",
+        "type": "String"
+      },
+      "detect.default.project.version.scheme": {
+        "description": "The scheme to use when the package managers can not determine a version, either 'text' or 'timestamp'",
+        "defaultValue": "text"
+      },
+      "detect.default.project.version.text": {
+        "description": "The text to use as the default project version",
+        "defaultValue": "Detect Unkown Version"
+      },
+      "detect.default.project.version.timeformat": {
+        "description": "The timestamp format to use as the default project version",
+        "defaultValue": "yyyy-MM-dd'T'HH:mm:ss.SSS"
+      },
+      "detect.risk.report.pdf": {
+        "description": "When set to true, a Black Duck risk report in PDF form will be created",
+        "defaultValue": "false",
+        "defaultValue": "Boolean"
+      },
+      "detect.risk.report.pdf.path": {
+        "description": "The output directory for risk report in PDF. Default is the source directory",
+        "defaultValue": "."
+      },
+      "detect.notices.report": {
+        "description": "When set to true, a Black Duck notices report in text form will be created in your source directory",
+        "defaultValue": "false",
+        "defaultValue": "Boolean"
+      },
+      "detect.notices.report.path": {
+        "description": "The output directory for notices report. Default is the source directory",
+        "defaultValue": "."
+      },
+      "logging.pattern.console${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}": {
+        "description": "The logging level to run Detect at",
+        "defaultValue": "INFO",
+        "type": "String"
+      }
+  },
+  "hub configuration": {
+    "blackduck.hub.url": {
+      "description": "URL of the Hub server",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.timeout": {
+      "description": "Time to wait for rest connections to complete",
+      "defaultValue": "120"
+    },
+    "blackduck.hub.username": {
+      "description": "Hub username",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.password": {
+      "description": "Hub password",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.auto.import.cert": {
+      "description": "If true the Hub https certificate will be automatically imported",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "blackduck.hub.offline.mode": {
+      "description": "This can disable any Hub communication - if true, Detect will not upload BDIO files, it will not check policies, and it will not download and install the signature scanner",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "blackduck.hub.proxy.host": {
+      "description": "Proxy host",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.proxy.port": {
+      "description": "Proxy port",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.proxy.username": {
+      "description": "Proxy username",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "blackduck.hub.proxy.password": {
+      "description": "Project password",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "logging": {
+    "detect.suppress.configuration.output": {
+      "description": "If true, the default behavior of printing your configuration properties at startup will be suppressed",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "logging.level.com.blackducksoftware.integrationINFO": {
+      "description": "The logging level of Detect (ALL|TRACE|DEBUG|INFO|WARN|ERROR|FATAL|OFF)",
+      "defaultValue": "INFO"
+    }
+  },
+  "cleanup": {
+    "detect.cleanup.bom.tool.files": {
+      "description": "Detect creates temporary files in the output directory. If set to true this will clean them up after execution",
+      "defaultValue": "true",
+      "defaultValue": "Boolean"
+    },
+    "detect.cleanup.bdio.files": {
+      "description": "If true the bdio files will be deleted after upload",
+      "defaultValue": "true",
+      "defaultValue": "Boolean"
+    }
+  },
+  "paths": {
+    "detect.source.path": {
+      "description": "Source path to inspect",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.output.path": {
+      "description": "Output path",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.search.depth": {
+      "description": "Depth from source paths to search for files.",
+      "defaultValue": "3"
+    },
+    "detect.bash.path": {
+      "description": "Path of the bash executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "bomtool": {
+    "detect.excluded.bom.tool.types": {
+      "description": "By default, all tools will be included. If you want to exclude specific tools, specify the ones to exclude here. Exclusion rules always win.",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.included.bom.tool.types": {
+      "description": "By default, all tools will be included. If you want to include only specific tools, specify the ones to include here. Exclusion rules always win.",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "conda": {
+    "detect.conda.path": {
+      "description": "The path to the conda executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.conda.environment.name": {
+      "description": "The name of the anaconda environment used by your project",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "cpan": {
+    "detect.cpan.path": {
+      "description": "The path to the cpan executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.cpanm.path": {
+      "description": "The path to the cpanm executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.perl.path": {
+      "description": "The path to the perl executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "docker": {
+    "detect.docker.inspector.path": {
+      "description": "This is used to override using the hosted script by github url. You can provide your own script at this path",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.docker.inspector.version": {
+      "description": "Version of the Hub Docker Inspector to use",
+      "defaultValue": "latest"
+    },
+    "detect.docker.tar": {
+      "description": "A saved docker image - must be a .tar file. For detect to run docker either this property or detect.docker.image must be set",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.docker.image": {
+      "description": "The docker image name to inspect. For detect to run docker either this property or detect.docker.tar must be set",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.docker.path": {
+      "description": "The path to the docker executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "go": {
+    "detect.go.dep.path": {
+      "description": "The path to the Go Dep executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "gradle": {
+    "detect.gradle.inspector.version": {
+      "description": "Version of the Gradle Inspector",
+      "defaultValue": "0.2.1"
+    },
+    "detect.gradle.inspector.air.gap.path": {
+      "description": "The path to the directory containing the air gap dependencies for the gradle inspector",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.path": {
+      "description": "The path to the Gradle executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.build.command": {
+      "description": "Gradle build command",
+      "defaultValue": "dependencies"
+    },
+    "detect.gradle.excluded.configurations": {
+      "description": "The names of the dependency configurations to exclude",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.included.configurations": {
+      "description": "The names of the dependency configurations to include",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.excluded.projects": {
+      "description": "The names of the projects to exclude",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.included.projects": {
+      "description": "The names of the projects to include",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.gradle.cleanup.build.blackduck.directory": {
+      "description": "Set this to false if you do not want the 'blackduck' directory in your build directory to be deleted",
+      "defaultValue": "true",
+      "defaultValue": "Boolean"
+    }
+  },
+  "maven": {
+    "detect.maven.scope": {
+      "description": "The name of the dependency scope to include",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.maven.path": {
+      "description": "The path to the Maven executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "npm": {
+    "detect.npm.path": {
+      "description": "The path to the Npm executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+ },
+  "nuget": {
+    "detect.nuget.inspector.name": {
+      "description": "Name of the Nuget Inspector",
+      "defaultValue": "IntegrationNugetInspector"
+    },
+    "detect.nuget.inspector.version": {
+      "description": "Version of the Nuget Inspector",
+      "defaultValue": "2.0.0"
+    },
+    "detect.nuget.inspector.air.gap.path": {
+      "description": "The path to the nuget inspector nupkg file",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.nuget.packages.repo.url": {
+      "description": "The source for nuget packages",
+      "defaultValue": "https://www.nuget.org/api/v2/"
+    },
+    "detect.nuget.ignore.failure": {
+      "description": "If true errors will be logged and then ignored",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "detect.nuget.excluded.modules": {
+      "description": "The names of the projects in a solution to exclude",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.nuget.path": {
+      "description": "The path to the Nuget executable",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "packagist": {
+    "detect.packagist.include.dev.dependencies": {
+      "description": "Set this value to false if you would like to exclude your dev requires dependencies when ran",
+      "defaultValue": "true",
+      "defaultValue": "Boolean"
+    }
+  },
+  "pear": {
+    "detect.pear.path": {
+      "description": "The path to the Pear executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.pear.not.required.dependencies": {
+      "description": "Set to true if you would like to include the packages that are not required",
+      "defaultValue": "false",
+      "type": "Boolean"
+    }
+  },
+  "pip": {
+    "detect.python.path": {
+      "description": "The path to the python executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.pip.path": {
+      "description": "The path to the pip executable",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.pip.project.name": {
+      "description": "Override for pip inspector to find your project",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.pip.pip3": {
+      "description": "If true, detect will use pip3 if available on path",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "detect.pip.requirements.path": {
+      "description": "The path to a requirements file",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.pip.virtualEnv.path": {
+      "description": "The path to a user's virtual environment",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "policy check": {
+    "detect.policy.check": {
+      "description": "Set to true if you would like a policy check from the hub for your project",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "detect.policy.check.timeout": {
+      "description": "Timeout for the Hub's policy check response. When changing this value, keep in mind the checking of policies might have to wait for a new scan to process which can take some time",
+      "defaultValue": "300000"
+    }
+  },
+  "sbt": {
+    "detect.sbt.excluded.configurations": {
+      "description": "The names of the sbt configurations to exclude",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.sbt.included.configurations": {
+      "description": "The names of the sbt configurations to include",
+      "defaultValue": "",
+        "type": "String"
+    }
+  },
+  "signiture scanner": {
+    "detect.hub.signature.scanner.relative.paths.to.exclude": {
+      "description": "The relative paths of directories to be excluded from scan registration",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.hub.signature.scanner.exclusion.patterns": {
+      "description": "Enables you to specify sub-directories to exclude from scans",
+      "defaultValue": "",
+        "type": "String"
+    },
+    "detect.hub.signature.scanner.paths": {
+      "description": "These paths and only these paths will be scanned",
+      "defaultValue": "",
+        "type": "String",
+      "type": "String[]"
+    },
+    "detect.hub.signature.scanner.memory": {
+      "description": "The memory for the scanner to use",
+      "defaultValue": "4096",
+      "type": "Integer"
+    },
+    "detect.hub.signature.scanner.disabled": {
+      "description": "Set to true to disable the Hub Signature Scanner",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "detect.hub.signature.scanner.dry.run": {
+      "description": "If set to true, the signature scanner results will not be uploaded to the Hub and the scanner results will be written to disk",
+      "defaultValue": "false",
+      "type": "Boolean"
+    },
+    "detect.hub.signature.scanner.offline.local.path": {
+      "description": "To use a local signature scanner, set its location with this property. This will be the path that contains the 'Hub_Scan_Installation' directory where the signature scanner was unzipped",
+      "defaultValue": "",
+        "type": "String"
+    },
+  }
+}

--- a/src/main/resources/properties.json
+++ b/src/main/resources/properties.json
@@ -13,7 +13,7 @@
       "detect.project.level.adjustments": {
         "description": "An override for the Project level matches",
         "defaultValue": "true",
-        "defaultValue": "Boolean"
+        "type": "Boolean"
       },
       "detect.project.version.name": {
         "description": "An override for the version to use for the Hub project. If not supplied, detect will attempt to use the tools to figure out a reasonable version name. If that fails, the current date will be used",
@@ -22,11 +22,13 @@
       },
       "detect.project.version.phase": {
         "description": "An override for the Project Version phase",
-        "defaultValue": "Development"
+        "defaultValue": "Development",
+        "type": "String"
       },
       "detect.project.version.distribution": {
         "description": "An override for the Project Version distribution",
-        "defaultValue": "External"
+        "defaultValue": "External",
+        "type": "String"
       },
       "detect.project.codelocation.prefix": {
         "description": "A prefix to the name of the codelocations created by Detect. Useful for running against the same projects on multiple machines",
@@ -35,37 +37,37 @@
       },
       "detect.default.project.version.scheme": {
         "description": "The scheme to use when the package managers can not determine a version, either 'text' or 'timestamp'",
-        "defaultValue": "text"
+        "defaultValue": "text",
+        "type": "String"
       },
       "detect.default.project.version.text": {
         "description": "The text to use as the default project version",
-        "defaultValue": "Detect Unkown Version"
+        "defaultValue": "Detect Unkown Version",
+        "type": "String"
       },
       "detect.default.project.version.timeformat": {
         "description": "The timestamp format to use as the default project version",
-        "defaultValue": "yyyy-MM-dd'T'HH:mm:ss.SSS"
+        "defaultValue": "yyyy-MM-dd'T'HH:mm:ss.SSS",
+        "type": "String"
       },
       "detect.risk.report.pdf": {
         "description": "When set to true, a Black Duck risk report in PDF form will be created",
         "defaultValue": "false",
-        "defaultValue": "Boolean"
+        "type": "Boolean"
       },
       "detect.risk.report.pdf.path": {
         "description": "The output directory for risk report in PDF. Default is the source directory",
-        "defaultValue": "."
+        "defaultValue": ".",
+        "type": "String"
       },
       "detect.notices.report": {
         "description": "When set to true, a Black Duck notices report in text form will be created in your source directory",
         "defaultValue": "false",
-        "defaultValue": "Boolean"
+        "type": "Boolean"
       },
       "detect.notices.report.path": {
         "description": "The output directory for notices report. Default is the source directory",
-        "defaultValue": "."
-      },
-      "logging.pattern.console${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}": {
-        "description": "The logging level to run Detect at",
-        "defaultValue": "INFO",
+        "defaultValue": ".",
         "type": "String"
       }
   },
@@ -77,7 +79,8 @@
     },
     "blackduck.hub.timeout": {
       "description": "Time to wait for rest connections to complete",
-      "defaultValue": "120"
+      "defaultValue": "120",
+      "type": "Integer"
     },
     "blackduck.hub.username": {
       "description": "Hub username",
@@ -112,12 +115,12 @@
     "blackduck.hub.proxy.username": {
       "description": "Proxy username",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "blackduck.hub.proxy.password": {
       "description": "Project password",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "logging": {
@@ -126,21 +129,27 @@
       "defaultValue": "false",
       "type": "Boolean"
     },
-    "logging.level.com.blackducksoftware.integrationINFO": {
+    "logging.level.com.blackducksoftware.integration": {
       "description": "The logging level of Detect (ALL|TRACE|DEBUG|INFO|WARN|ERROR|FATAL|OFF)",
-      "defaultValue": "INFO"
+      "defaultValue": "INFO",
+      "type": "String"
+    },
+    "logging.pattern.console": {
+      "description": "The logging level to run Detect at",
+      "defaultValue": "${LOG_LEVEL_PATTERN}%clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}",
+      "type": "String"
     }
   },
   "cleanup": {
     "detect.cleanup.bom.tool.files": {
       "description": "Detect creates temporary files in the output directory. If set to true this will clean them up after execution",
       "defaultValue": "true",
-      "defaultValue": "Boolean"
+      "type": "Boolean"
     },
     "detect.cleanup.bdio.files": {
       "description": "If true the bdio files will be deleted after upload",
       "defaultValue": "true",
-      "defaultValue": "Boolean"
+      "type": "Boolean"
     }
   },
   "paths": {
@@ -156,169 +165,176 @@
     },
     "detect.search.depth": {
       "description": "Depth from source paths to search for files.",
-      "defaultValue": "3"
+      "defaultValue": "3",
+      "type": "Integer"
     },
     "detect.bash.path": {
       "description": "Path of the bash executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "bomtool": {
     "detect.excluded.bom.tool.types": {
       "description": "By default, all tools will be included. If you want to exclude specific tools, specify the ones to exclude here. Exclusion rules always win.",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.included.bom.tool.types": {
       "description": "By default, all tools will be included. If you want to include only specific tools, specify the ones to include here. Exclusion rules always win.",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "conda": {
     "detect.conda.path": {
       "description": "The path to the conda executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.conda.environment.name": {
       "description": "The name of the anaconda environment used by your project",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "cpan": {
     "detect.cpan.path": {
       "description": "The path to the cpan executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.cpanm.path": {
       "description": "The path to the cpanm executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.perl.path": {
       "description": "The path to the perl executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "docker": {
     "detect.docker.inspector.path": {
       "description": "This is used to override using the hosted script by github url. You can provide your own script at this path",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.docker.inspector.version": {
       "description": "Version of the Hub Docker Inspector to use",
-      "defaultValue": "latest"
+      "defaultValue": "latest",
+      "type": "String"
     },
     "detect.docker.tar": {
       "description": "A saved docker image - must be a .tar file. For detect to run docker either this property or detect.docker.image must be set",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.docker.image": {
       "description": "The docker image name to inspect. For detect to run docker either this property or detect.docker.tar must be set",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.docker.path": {
       "description": "The path to the docker executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "go": {
     "detect.go.dep.path": {
       "description": "The path to the Go Dep executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "gradle": {
     "detect.gradle.inspector.version": {
       "description": "Version of the Gradle Inspector",
-      "defaultValue": "0.2.1"
+      "defaultValue": "0.2.1",
+      "type": "String"
     },
     "detect.gradle.inspector.air.gap.path": {
       "description": "The path to the directory containing the air gap dependencies for the gradle inspector",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.path": {
       "description": "The path to the Gradle executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.build.command": {
       "description": "Gradle build command",
-      "defaultValue": "dependencies"
+      "defaultValue": "dependencies",
+      "type": "String"
     },
     "detect.gradle.excluded.configurations": {
       "description": "The names of the dependency configurations to exclude",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.included.configurations": {
       "description": "The names of the dependency configurations to include",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.excluded.projects": {
       "description": "The names of the projects to exclude",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.included.projects": {
       "description": "The names of the projects to include",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.gradle.cleanup.build.blackduck.directory": {
       "description": "Set this to false if you do not want the 'blackduck' directory in your build directory to be deleted",
       "defaultValue": "true",
-      "defaultValue": "Boolean"
+      "type": "Boolean"
     }
   },
   "maven": {
     "detect.maven.scope": {
       "description": "The name of the dependency scope to include",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.maven.path": {
       "description": "The path to the Maven executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "npm": {
     "detect.npm.path": {
       "description": "The path to the Npm executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
  },
   "nuget": {
     "detect.nuget.inspector.name": {
       "description": "Name of the Nuget Inspector",
-      "defaultValue": "IntegrationNugetInspector"
+      "defaultValue": "IntegrationNugetInspector",
+      "type": "String"
     },
     "detect.nuget.inspector.version": {
       "description": "Version of the Nuget Inspector",
-      "defaultValue": "2.0.0"
+      "defaultValue": "2.0.0",
+      "type": "String"
     },
     "detect.nuget.inspector.air.gap.path": {
       "description": "The path to the nuget inspector nupkg file",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.nuget.packages.repo.url": {
       "description": "The source for nuget packages",
-      "defaultValue": "https://www.nuget.org/api/v2/"
+      "defaultValue": "https://www.nuget.org/api/v2/",
+      "type": "String"
     },
     "detect.nuget.ignore.failure": {
       "description": "If true errors will be logged and then ignored",
@@ -328,26 +344,26 @@
     "detect.nuget.excluded.modules": {
       "description": "The names of the projects in a solution to exclude",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.nuget.path": {
       "description": "The path to the Nuget executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "packagist": {
     "detect.packagist.include.dev.dependencies": {
       "description": "Set this value to false if you would like to exclude your dev requires dependencies when ran",
       "defaultValue": "true",
-      "defaultValue": "Boolean"
+      "type": "Boolean"
     }
   },
   "pear": {
     "detect.pear.path": {
       "description": "The path to the Pear executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.pear.not.required.dependencies": {
       "description": "Set to true if you would like to include the packages that are not required",
@@ -359,17 +375,17 @@
     "detect.python.path": {
       "description": "The path to the python executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.pip.path": {
       "description": "The path to the pip executable",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.pip.project.name": {
       "description": "Override for pip inspector to find your project",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.pip.pip3": {
       "description": "If true, detect will use pip3 if available on path",
@@ -379,12 +395,12 @@
     "detect.pip.requirements.path": {
       "description": "The path to a requirements file",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.pip.virtualEnv.path": {
       "description": "The path to a user's virtual environment",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "policy check": {
@@ -395,36 +411,36 @@
     },
     "detect.policy.check.timeout": {
       "description": "Timeout for the Hub's policy check response. When changing this value, keep in mind the checking of policies might have to wait for a new scan to process which can take some time",
-      "defaultValue": "300000"
+      "defaultValue": "300000",
+      "type": "Long"
     }
   },
   "sbt": {
     "detect.sbt.excluded.configurations": {
       "description": "The names of the sbt configurations to exclude",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     },
     "detect.sbt.included.configurations": {
       "description": "The names of the sbt configurations to include",
       "defaultValue": "",
-        "type": "String"
+      "type": "String"
     }
   },
   "signiture scanner": {
     "detect.hub.signature.scanner.relative.paths.to.exclude": {
       "description": "The relative paths of directories to be excluded from scan registration",
       "defaultValue": "",
-        "type": "String"
+      "type": "String[]"
     },
     "detect.hub.signature.scanner.exclusion.patterns": {
       "description": "Enables you to specify sub-directories to exclude from scans",
       "defaultValue": "",
-        "type": "String"
+      "type": "String[]"
     },
     "detect.hub.signature.scanner.paths": {
       "description": "These paths and only these paths will be scanned",
       "defaultValue": "",
-        "type": "String",
       "type": "String[]"
     },
     "detect.hub.signature.scanner.memory": {
@@ -445,7 +461,7 @@
     "detect.hub.signature.scanner.offline.local.path": {
       "description": "To use a local signature scanner, set its location with this property. This will be the path that contains the 'Hub_Scan_Installation' directory where the signature scanner was unzipped",
       "defaultValue": "",
-        "type": "String"
-    },
+      "type": "String"
+    }
   }
 }

--- a/src/main/resources/properties.json
+++ b/src/main/resources/properties.json
@@ -427,7 +427,7 @@
       "type": "String"
     }
   },
-  "signiture scanner": {
+  "signature scanner": {
     "detect.hub.signature.scanner.relative.paths.to.exclude": {
       "description": "The relative paths of directories to be excluded from scan registration",
       "defaultValue": "",


### PR DESCRIPTION
Currently the process for adding a new parameter to detect is tedious and no fun at all.
The process requires you to add an entry to the applications.properties file, then add an entry to DetectProperties which includes the value's description as well as default values. Then you have to add a wrapper method in DetectConfiguration to access the new property. A longer description can be found in the Jira ticket DETECT-193

Now you just modify the properties.json file in /src/main/resources/ and the next time you build, a new application.properties file and a new DetectProperties.groovy will be generated for you.