### PR TITLE
fixing npm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.blackducksoftware.integration:hub-common:14.5.0'
+    compile 'com.blackducksoftware.integration:hub-common:14.5.1'
     compile 'org.springframework.boot:spring-boot-starter'
     compile 'org.apache.maven.shared:maven-invoker:3.0.0'
     compile 'com.esotericsoftware.yamlbeans:yamlbeans:1.11'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -143,7 +143,7 @@ class DetectProperties {
     @Value('${detect.policy.check.timeout}')
     Long policyCheckTimeout
 
-    @ValueDescription(description="Version of the Gradle Inspector", defaultValue="0.1.0", group=DetectProperties.GROUP_GRADLE)
+    @ValueDescription(description="Version of the Gradle Inspector", defaultValue="0.2.2", group=DetectProperties.GROUP_GRADLE)
     @Value('${detect.gradle.inspector.version}')
     String gradleInspectorVersion
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/npm/NpmCliDependencyFinder.groovy
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import com.blackducksoftware.integration.hub.bdio.simple.DependencyNodeBuilder
 import com.blackducksoftware.integration.hub.bdio.simple.model.DependencyNode
 import com.blackducksoftware.integration.hub.bdio.simple.model.Forge
 import com.blackducksoftware.integration.hub.bdio.simple.model.externalid.NameVersionExternalId
@@ -81,12 +82,13 @@ class NpmCliDependencyFinder {
         def externalId = new NameVersionExternalId(Forge.NPM, projectName, projectVersion)
         def dependencyNode = new DependencyNode(projectName, projectVersion, externalId)
 
-        populateChildren(dependencyNode, npmJson.getAsJsonObject(JSON_DEPENDENCIES))
+        DependencyNodeBuilder dependencyNodeBuilder = new DependencyNodeBuilder(dependencyNode)
+        populateChildren(dependencyNodeBuilder, dependencyNode, npmJson.getAsJsonObject(JSON_DEPENDENCIES))
 
         dependencyNode
     }
 
-    private void populateChildren(DependencyNode parentDependencyNode, JsonObject parentNodeChildren) {
+    private void populateChildren(DependencyNodeBuilder dependencyNodeBuilder, DependencyNode parentDependencyNode, JsonObject parentNodeChildren) {
         def elements = parentNodeChildren?.entrySet()
         elements?.each {
             String name = it.key
@@ -96,8 +98,8 @@ class NpmCliDependencyFinder {
             def externalId = new NameVersionExternalId(Forge.NPM, name, version)
             def newNode = new DependencyNode(name, version, externalId)
 
-            populateChildren(newNode, children)
-            parentDependencyNode.children.add(newNode)
+            populateChildren(dependencyNodeBuilder, newNode, children)
+            dependencyNodeBuilder.addChildNodeWithParents(newNode, [parentDependencyNode])
         }
     }
 }


### PR DESCRIPTION
The gradle property was changed because the inspector relied on an older version of bdio, and I'm not a huge fan of having divergent dependencies.

The new version of hub-common has the latest integration-bdio library which fixed the builder, which allowed us to use it again in npm...which fixed everything.