### PR TITLE
refactor executable names to handle multiple executable extensions

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CondaBomTool.groovy
@@ -61,7 +61,7 @@ class CondaBomTool extends BomTool {
         if (containsFiles) {
             condaExecutablePath = findExecutablePath(ExecutableType.CONDA, true, detectConfiguration.getCondaPath())
             if (!condaExecutablePath) {
-                logger.warn("Could not find the ${executableManager.getExecutableName(ExecutableType.CONDA)} executable")
+                logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.CONDA).join(' or ')} executable")
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/CpanBomTool.groovy
@@ -64,10 +64,10 @@ class CpanBomTool extends BomTool {
             cpanExecutablePath = findExecutablePath(ExecutableType.CPAN, true, detectConfiguration.getCpanPath())
             cpanmExecutablePath = findExecutablePath(ExecutableType.CPANM, true, detectConfiguration.getCpanmPath())
             if (!cpanExecutablePath) {
-                logger.warn("Could not find the ${executableManager.getExecutableName(ExecutableType.CPAN)} executable")
+                logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.CPAN).join(' or ')} executable")
             }
             if (!cpanmExecutablePath) {
-                logger.warn("Could not find the ${executableManager.getExecutableName(ExecutableType.CPANM)} executable")
+                logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.CPANM).join(' or ')} executable")
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -76,10 +76,10 @@ class DockerBomTool extends BomTool {
             dockerExecutablePath = findExecutablePath(ExecutableType.DOCKER, true, detectConfiguration.dockerPath)
             bashExecutablePath = findExecutablePath(ExecutableType.BASH, true, detectConfiguration.bashPath)
             if (!dockerExecutablePath) {
-                logger.warn("Could not find a ${executableManager.getExecutableName(ExecutableType.DOCKER)} executable")
+                logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.DOCKER).join(' or ')} executable")
             }
             if (!bashExecutablePath) {
-                logger.warn("Could not find a ${executableManager.getExecutableName(ExecutableType.BASH)} executable")
+                logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.BASH).join(' or ')} executable")
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
@@ -144,6 +144,6 @@ class GoDepBomTool extends BomTool {
 
     private File getBuiltGoDep() {
         def goOutputDirectory = new File(detectConfiguration.outputDirectory, 'Go')
-        new File(goOutputDirectory, executableManager.getDefaultExecutableName(ExecutableType.GO_DEP))
+        new File(goOutputDirectory, executableManager.getExecutableNames(ExecutableType.GO_DEP)[0])
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GoDepBomTool.groovy
@@ -86,7 +86,7 @@ class GoDepBomTool extends BomTool {
             goExecutablePath = executableManager.getExecutablePath(ExecutableType.GO, true, sourcePath)
         }
         if (isTheBestGoBomTool && !goExecutablePath) {
-            logger.warn("Could not find the ${executableManager.getExecutableName(ExecutableType.GO)} executable")
+            logger.warn("Could not find the ${executableManager.getExecutableNames(ExecutableType.GO).join(' or ')} executable")
         }
 
         goExecutablePath && isTheBestGoBomTool
@@ -144,6 +144,6 @@ class GoDepBomTool extends BomTool {
 
     private File getBuiltGoDep() {
         def goOutputDirectory = new File(detectConfiguration.outputDirectory, 'Go')
-        new File(goOutputDirectory, executableManager.getExecutableName(ExecutableType.GO_DEP))
+        new File(goOutputDirectory, executableManager.getDefaultExecutableName(ExecutableType.GO_DEP))
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
@@ -97,7 +97,7 @@ class NpmBomTool extends BomTool {
         } else if (containsPackageJson && containsNodeModules) {
             npmExePath = findExecutablePath(ExecutableType.NPM, true, detectConfiguration.getNpmPath())
             if (!npmExePath) {
-                logger.warn("Could not find an ${executableManager.getExecutableName(ExecutableType.NPM)} executable")
+                logger.warn("Could not find an ${executableManager.getExecutableNames(ExecutableType.NPM).join(' or ')} executable")
             } else {
                 npmLsExe = new Executable(new File(sourcePath), npmExePath, ['-version'])
                 String npmNodePath = detectConfiguration.getNpmNodePath()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -63,7 +63,7 @@ class NugetBomTool extends BomTool {
         if (containsSolutionFile || containsProjectFile) {
             nugetExecutable = findExecutablePath(ExecutableType.NUGET, true, detectConfiguration.getNugetPath())
             if (!nugetExecutable) {
-                logger.warn("Could not find a ${executableManager.getExecutableName(ExecutableType.NUGET)} executable")
+                logger.warn("Could not find a ${executableManager.getExecutableNames(ExecutableType.NUGET).join(' or ')} executable")
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PearBomTool.groovy
@@ -63,7 +63,7 @@ class PearBomTool extends BomTool {
         if (containsPackageXml) {
             pearExePath = findExecutablePath(ExecutableType.PEAR, true, detectConfiguration.getPearPath())
             if (!pearExePath) {
-                logger.warn("Could not find a ${executableManager.getExecutableName(ExecutableType.PEAR)} executable")
+                logger.warn("Could not find a ${executableManager.getExecutableNames(ExecutableType.PEAR).join(' or ')} executable")
             }
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/type/ExecutableType.groovy
@@ -26,40 +26,40 @@ import groovy.transform.TypeChecked
 
 @TypeChecked
 enum ExecutableType {
-    BASH([(OperatingSystemType.WINDOWS): 'bash.exe', (OperatingSystemType.LINUX): 'bash']),
-    CONDA([(OperatingSystemType.WINDOWS): 'conda.exe', (OperatingSystemType.LINUX): 'conda']),
-    CPAN([(OperatingSystemType.WINDOWS): 'cpan.bat', (OperatingSystemType.LINUX): 'cpan']),
-    CPANM([(OperatingSystemType.WINDOWS): 'cpanm.bat', (OperatingSystemType.LINUX): 'cpanm']),
-    DOCKER([(OperatingSystemType.WINDOWS): 'docker.exe', (OperatingSystemType.LINUX): 'docker']),
-    GO([(OperatingSystemType.WINDOWS): 'go.exe', (OperatingSystemType.LINUX): 'go']),
-    GO_DEP([(OperatingSystemType.WINDOWS): 'dep.exe', (OperatingSystemType.LINUX): 'dep']),
-    GRADLE([(OperatingSystemType.WINDOWS): 'gradle.bat', (OperatingSystemType.LINUX): 'gradle']),
-    GRADLEW([(OperatingSystemType.WINDOWS): 'gradlew.bat', (OperatingSystemType.LINUX): 'gradlew']),
-    MVN([(OperatingSystemType.WINDOWS): 'mvn.cmd', (OperatingSystemType.LINUX): 'mvn']),
-    MVNW([(OperatingSystemType.WINDOWS): 'mvnw.bat', (OperatingSystemType.LINUX): 'mvnw']),
-    NPM([(OperatingSystemType.WINDOWS): 'npm.cmd', (OperatingSystemType.LINUX): 'npm']),
-    NUGET([(OperatingSystemType.WINDOWS): 'nuget.exe', (OperatingSystemType.LINUX): 'nuget']),
-    PEAR([(OperatingSystemType.WINDOWS): 'pear.bat', (OperatingSystemType.LINUX): 'pear']),
-    PERL([(OperatingSystemType.WINDOWS): 'perl.bat', (OperatingSystemType.LINUX): 'perl']),
-    PIP([(OperatingSystemType.WINDOWS): 'pip.exe', (OperatingSystemType.LINUX): 'pip']),
-    PIP3([(OperatingSystemType.WINDOWS): 'pip3.exe', (OperatingSystemType.LINUX): 'pip3']),
-    PYTHON([(OperatingSystemType.WINDOWS): 'python.exe', (OperatingSystemType.LINUX): 'python']),
-    PYTHON3([(OperatingSystemType.WINDOWS): 'python3.exe', (OperatingSystemType.LINUX): 'python3']),
-    VIRTUALENV([(OperatingSystemType.WINDOWS): 'virtualenv.exe', (OperatingSystemType.LINUX): 'virtualenv'])
+    BASH([(OperatingSystemType.WINDOWS): ['bash.exe'], (OperatingSystemType.LINUX): ['bash']]),
+    CONDA([(OperatingSystemType.WINDOWS): ['conda.exe'], (OperatingSystemType.LINUX): ['conda']]),
+    CPAN([(OperatingSystemType.WINDOWS): ['cpan.bat', 'cpan.cmd'], (OperatingSystemType.LINUX): ['cpan']]),
+    CPANM([(OperatingSystemType.WINDOWS): ['cpanm.bat', 'cpanm.cmd'], (OperatingSystemType.LINUX): ['cpanm']]),
+    DOCKER([(OperatingSystemType.WINDOWS): ['docker.exe'], (OperatingSystemType.LINUX): ['docker']]),
+    GO([(OperatingSystemType.WINDOWS): ['go.exe'], (OperatingSystemType.LINUX): ['go']]),
+    GO_DEP([(OperatingSystemType.WINDOWS): ['dep.exe'], (OperatingSystemType.LINUX): ['dep']]),
+    GRADLE([(OperatingSystemType.WINDOWS): ['gradle.bat', 'gradle.cmd'], (OperatingSystemType.LINUX): ['gradle']]),
+    GRADLEW([(OperatingSystemType.WINDOWS): ['gradlew.bat', 'gradlew.cmd'], (OperatingSystemType.LINUX): ['gradlew']]),
+    MVN([(OperatingSystemType.WINDOWS): ['mvn.cmd', 'mvn.bat'], (OperatingSystemType.LINUX): ['mvn']]),
+    MVNW([(OperatingSystemType.WINDOWS): ['mvnw.bat', 'mvn.cmd'], (OperatingSystemType.LINUX): ['mvnw']]),
+    NPM([(OperatingSystemType.WINDOWS): ['npm.cmd', 'npm.bat'], (OperatingSystemType.LINUX): ['npm']]),
+    NUGET([(OperatingSystemType.WINDOWS): ['nuget.exe'], (OperatingSystemType.LINUX): ['nuget']]),
+    PEAR([(OperatingSystemType.WINDOWS): ['pear.bat'], (OperatingSystemType.LINUX): ['pear']]),
+    PERL([(OperatingSystemType.WINDOWS): ['perl.bat'], (OperatingSystemType.LINUX): ['perl']]),
+    PIP([(OperatingSystemType.WINDOWS): ['pip.exe'], (OperatingSystemType.LINUX): ['pip']]),
+    PIP3([(OperatingSystemType.WINDOWS): ['pip3.exe'], (OperatingSystemType.LINUX): ['pip3']]),
+    PYTHON([(OperatingSystemType.WINDOWS): ['python.exe'], (OperatingSystemType.LINUX): ['python']]),
+    PYTHON3([(OperatingSystemType.WINDOWS): ['python3.exe'], (OperatingSystemType.LINUX): ['python3']]),
+    VIRTUALENV([(OperatingSystemType.WINDOWS): ['virtualenv.exe'], (OperatingSystemType.LINUX): ['virtualenv']])
 
-    private Map<OperatingSystemType, String> osToExecutableMap = [:]
+    private Map<OperatingSystemType, List<String>> osToExecutableMap = [:]
 
-    private ExecutableType(Map<OperatingSystemType, String> osToExecutableMap) {
+    private ExecutableType(Map<OperatingSystemType, List<String>> osToExecutableMap) {
         this.osToExecutableMap.putAll(osToExecutableMap)
     }
 
     /**
      * If an operating system specific executable is not present, the linux executable, which could itself not be present, will be returned.
      */
-    public String getExecutable(OperatingSystemType operatingSystemType) {
-        String osSpecificExecutable = osToExecutableMap[operatingSystemType]
-        if (osSpecificExecutable) {
-            return osSpecificExecutable
+    public List<String> getExecutables(OperatingSystemType operatingSystemType) {
+        List<String> osSpecificExecutables = osToExecutableMap[operatingSystemType]
+        if (osSpecificExecutables) {
+            return osSpecificExecutables
         } else {
             return osToExecutableMap[OperatingSystemType.LINUX]
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
@@ -61,8 +61,13 @@ class ExecutableManager {
         }
     }
 
-    String getExecutableName(ExecutableType executableType) {
-        executableType.getExecutable(currentOs)
+    String getDefaultExecutableName(ExecutableType executableType) {
+        executableType.getExecutables(currentOs)[0]
+    }
+
+
+    List<String> getExecutableNames(ExecutableType executableType) {
+        executableType.getExecutables(currentOs)
     }
 
     String getExecutablePath(ExecutableType executableType, boolean searchSystemPath, String path) {
@@ -70,26 +75,28 @@ class ExecutableManager {
     }
 
     File getExecutable(ExecutableType executableType, boolean searchSystemPath, String path) {
-        String executable = getExecutableName(executableType)
+        List<String> executables = getExecutableNames(executableType)
         String searchPath = path.trim()
-        File executableFile = findExecutableFileFromPath(searchPath, executable)
+        File executableFile = findExecutableFileFromPath(searchPath, executables)
         if (searchSystemPath && !executableFile) {
-            executableFile = findExecutableFileFromSystemPath(executable)
+            executableFile = findExecutableFileFromSystemPath(executables)
         }
 
         executableFile
     }
 
-    private File findExecutableFileFromSystemPath(final String executable) {
+    private File findExecutableFileFromSystemPath(final List<String> executables) {
         String systemPath = System.getenv("PATH")
-        return findExecutableFileFromPath(systemPath, executable)
+        return findExecutableFileFromPath(systemPath, executables)
     }
 
-    private File findExecutableFileFromPath(final String path, String executable) {
+    private File findExecutableFileFromPath(final String path, List<String> executables) {
         for (String pathPiece : path.split(File.pathSeparator)) {
-            File foundFile = detectFileManager.findFile(pathPiece, executable)
-            if (foundFile && foundFile.canExecute()) {
-                return foundFile
+            for(String executable : executables) {
+                File foundFile = detectFileManager.findFile(pathPiece, executable)
+                if (foundFile && foundFile.canExecute()) {
+                    return foundFile
+                }
             }
         }
         null

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/executable/ExecutableManager.groovy
@@ -61,11 +61,6 @@ class ExecutableManager {
         }
     }
 
-    String getDefaultExecutableName(ExecutableType executableType) {
-        executableType.getExecutables(currentOs)[0]
-    }
-
-
     List<String> getExecutableNames(ExecutableType executableType) {
         executableType.getExecutables(currentOs)
     }


### PR DESCRIPTION
On windows, there are very little differences between .bat and .cmd suffixed files. It seems as a general rule that newer package managers use .cmd and older ones use .bat (see IDETECT-280) Because of this we could handle executable names as a list of possibilities, rather than defined x.bat or y.cmd