### PR TITLE
Fixing Docker bom tool issues

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
@@ -44,6 +44,7 @@ import com.blackducksoftware.integration.hub.detect.hub.HubServiceWrapper
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
 import com.blackducksoftware.integration.hub.detect.summary.DetectSummary
+import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
 import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableManager
 import com.blackducksoftware.integration.hub.model.view.ProjectVersionView
 import com.blackducksoftware.integration.log.Slf4jIntLogger
@@ -95,6 +96,9 @@ class Application {
     @Autowired
     DetectSummary detectSummary
 
+    @Autowired
+    DetectFileManager detectFileManager
+
     static void main(final String[] args) {
         new SpringApplicationBuilder(Application.class).logStartupInfo(false).run(args)
     }
@@ -138,6 +142,7 @@ class Application {
         if (!detectConfiguration.suppressResultsOutput) {
             detectSummary.logResults(new Slf4jIntLogger(logger))
         }
+        detectFileManager.cleanupDirectories()
         System.exit(postResult)
     }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -87,6 +87,7 @@ class DockerBomTool extends BomTool {
     }
 
     List<DetectCodeLocation> extractDetectCodeLocations() {
+        File workingDirectory = detectFileManager.createDirectory(getBomToolType())
         File shellScriptFile
         if (detectConfiguration.dockerInspectorPath) {
             shellScriptFile = new File(detectConfiguration.dockerInspectorPath)
@@ -96,11 +97,10 @@ class DockerBomTool extends BomTool {
                 hubDockerInspectorShellScriptUrl = new URL("https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-${detectConfiguration.dockerInspectorVersion}.sh")
             }
             String shellScriptContents = hubDockerInspectorShellScriptUrl.openStream().getText(StandardCharsets.UTF_8.toString())
-            shellScriptFile = detectFileManager.createFile(BomToolType.DOCKER, "hub-docker-inspector-${detectConfiguration.dockerInspectorVersion}.sh")
+            shellScriptFile = detectFileManager.createFile(workingDirectory, "hub-docker-inspector-${detectConfiguration.dockerInspectorVersion}.sh")
             detectFileManager.writeToFile(shellScriptFile, shellScriptContents)
             shellScriptFile.setExecutable(true)
         }
-        File workingDirectory = detectFileManager.createDirectory(getBomToolType())
 
         File dockerPropertiesFile = detectFileManager.createFile(workingDirectory, 'application.properties')
         dockerProperties.populatePropertiesFile(dockerPropertiesFile, workingDirectory)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -48,8 +48,8 @@ class DetectFileManager {
     private List<File> directoriesToCleanup = new ArrayList<>()
 
     public void cleanupDirectories() {
-        if(directoriesToCleanup) {
-            for(File directory : directoriesToCleanup) {
+        if (directoriesToCleanup) {
+            for (File directory : directoriesToCleanup) {
                 FileUtils.deleteDirectory(directory)
             }
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -50,7 +50,7 @@ class DetectFileManager {
     public void cleanupDirectories() {
         if (directoriesToCleanup) {
             for (File directory : directoriesToCleanup) {
-                FileUtils.deleteDirectory(directory)
+                FileUtils.deleteQuietly(directory)
             }
         }
     }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.detect.util
 
+import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -44,6 +45,16 @@ class DetectFileManager {
     @Autowired
     FileFinder fileFinder
 
+    private List<File> directoriesToCleanup = new ArrayList<>()
+
+    public void cleanupDirectories() {
+        if(directoriesToCleanup) {
+            for(File directory : directoriesToCleanup) {
+                FileUtils.deleteDirectory(directory)
+            }
+        }
+    }
+
     File createDirectory(BomToolType bomToolType) {
         createDirectory(bomToolType.toString().toLowerCase())
     }
@@ -56,10 +67,7 @@ class DetectFileManager {
         def newDirectory = new File(directory, newDirectoryName)
         newDirectory.mkdir()
         if (detectConfiguration.cleanupBomToolFiles) {
-            newDirectory.deleteOnExit()
-            for(File file : newDirectory.listFiles()) {
-                file.deleteOnExit()
-            }
+            directoriesToCleanup.add(newDirectory)
         }
 
         newDirectory

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectFileManager.groovy
@@ -57,6 +57,9 @@ class DetectFileManager {
         newDirectory.mkdir()
         if (detectConfiguration.cleanupBomToolFiles) {
             newDirectory.deleteOnExit()
+            for(File file : newDirectory.listFiles()) {
+                file.deleteOnExit()
+            }
         }
 
         newDirectory


### PR DESCRIPTION
The Docker Bom Tool is using the first file matching the pattern "*_dependencies.json" and it is not cleaning up after doing so. So it runs into an issue where it is using the *_dependencies.json from a previous run. It also seems to have the same issue with the tar file