### PR TITLE
Fixed line separators

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/PipBomTool.groovy
@@ -118,7 +118,7 @@ class PipBomTool extends BomTool {
                     setupFile.absolutePath,
                     '--name'
                 ])
-                String[] output = executableRunner.execute(findProjectNameExecutable).standardOutput.split(System.lineSeparator())
+                String[] output = executableRunner.execute(findProjectNameExecutable).standardOutput.split("\\r?\\n")
                 projectName = output[output.length - 1].replace('_', '-').trim()
             }
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanListParser.groovy
@@ -39,7 +39,7 @@ class CpanListParser {
     public Map<String, NameVersionNode> parse(String listText) {
         Map<String, NameVersionNode> moduleMap = [:]
 
-        for (String line: listText.split(System.lineSeparator())) {
+        for (String line: listText.split("\\r?\\n")) {
             if (!line.trim()) {
                 continue
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cpan/CpanPackager.groovy
@@ -66,7 +66,7 @@ class CpanPackager {
 
     private List<String> getDirectModuleNames(String directDependenciesText) {
         List<String> modules = []
-        for (String line : directDependenciesText.split(System.lineSeparator())) {
+        for (String line : directDependenciesText.split("\\r?\\n")) {
             if (!line?.trim()) {
                 continue
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackRatNodeParser.groovy
@@ -49,7 +49,7 @@ public class PackRatNodeParser {
         directDependencyNames = new HashSet<>()
         currentParent = null
 
-        String[] lines = packratLockContents.split(System.lineSeparator())
+        String[] lines = packratLockContents.split("\\r?\\n")
         String name
         String version
         List<DependencyNode> projectDependencies = []

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/cran/PackratPackager.groovy
@@ -43,7 +43,7 @@ public class PackratPackager {
     }
 
     public String getProjectName(final String descriptionContents) {
-        String[] lines = descriptionContents.split(System.lineSeparator())
+        String[] lines = descriptionContents.split("\\r?\\n")
         String name
 
         for (String line : lines) {
@@ -57,7 +57,7 @@ public class PackratPackager {
     }
 
     public String getVersion(String descriptionContents) {
-        String[] lines = descriptionContents.split(System.lineSeparator())
+        String[] lines = descriptionContents.split("\\r?\\n")
         String versionLine = lines.find { it.contains('Version: ') }
 
         if (versionLine != null) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/go/vndr/VndrParser.groovy
@@ -34,7 +34,7 @@ class VndrParser {
     public List<DependencyNode> parseVendorConf(String vendorConfContents) {
         List<DependencyNode> nodes = new ArrayList<>()
         String contents = vendorConfContents.trim()
-        def lines = contents.split(System.lineSeparator())
+        def lines = contents.split("\\r?\\n")
         //TODO test against moby
         lines.each { String line ->
             if (line?.trim() && !line.startsWith('#')) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/maven/MavenCodeLocationPackager.groovy
@@ -58,7 +58,7 @@ class MavenCodeLocationPackager {
         dependencyParentStack = new Stack<>()
         parsingProjectSection = false
         level = 0
-        for (String line : mavenOutputText.split(System.lineSeparator())) {
+        for (String line : mavenOutputText.split("\\r?\\n")) {
             if (!(line ==~ /\[.*INFO.*\].*/) || line ==~ /\[.*INFO.*\].*Downloaded:.*/ || line ==~ /\[.*INFO.*\].*Downloading:.*/) {
                 // If the line does not start with [INFO] and have content, we will ignore it
                 // We also ignore lines for downloads

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pear/PearDependencyFinder.groovy
@@ -69,7 +69,7 @@ class PearDependencyFinder {
 
     private List<String> findDependencyNames(String list) {
         def nameList = []
-        String[] content = list.split(System.lineSeparator())
+        String[] content = list.split("\\r?\\n")
 
         if (content.size() > 5) {
             def listing = content[5..-1]
@@ -97,7 +97,7 @@ class PearDependencyFinder {
 
     private Set<DependencyNode> createPearDependencyNodeFromList(String list, List<String> dependencyNames) {
         Set<DependencyNode> childrenNodes = []
-        String[] dependencyList = list.split(System.lineSeparator())
+        String[] dependencyList = list.split("\\r?\\n")
 
         if (dependencyList.size() > 3) {
             def listing = dependencyList[3..-1]

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorTreeParser.groovy
@@ -47,7 +47,7 @@ class PipInspectorTreeParser {
     public static final String INDENTATION = ' '.multiply(4)
 
     DependencyNode parse(String treeText) {
-        def lines = treeText.trim().split(System.lineSeparator()).toList()
+        def lines = treeText.trim().split("\\r?\\n").toList()
 
         DependencyNodeBuilder dependencyNodeBuilder = null
         Stack<DependencyNode> tree = new Stack<>()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/rubygems/GemlockNodeParser.groovy
@@ -53,7 +53,7 @@ class GemlockNodeParser {
         currentParent = null
 
         List<DependencyNode> projectDependencies = []
-        String[] lines = gemfileLockContents.split(System.lineSeparator())
+        String[] lines = gemfileLockContents.split("\\r?\\n")
         for (String line : lines) {
             if (!line?.trim()) {
                 inSpecsSection = false

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/yarn/YarnPackager.groovy
@@ -49,7 +49,7 @@ class YarnPackager {
 
         NameVersionNode currentNode = null
         boolean dependenciesStarted = false
-        for (String line : yarnLockText.split(System.lineSeparator())) {
+        for (String line : yarnLockText.split("\\r?\\n")) {
             if (!line.trim()) {
                 continue
             }

--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -32,6 +32,13 @@ DETECT_JAR_PATH=${DETECT_JAR_PATH:-/tmp}
 
 DETECT_JAVA_OPTS=${DETECT_JAVA_OPTS:-}
 
+# If you want to pass any additional options to
+# curl, specify DETECT_CURL_OPTS in your environment.
+# For exmaple, to specify a proxy, you would set
+# DETECT_CURL_OPTS=--proxy http://myproxy:3128
+
+DETECT_CURL_OPTS=${DETECT_CURL_OPTS:-}
+
 SCRIPT_ARGS="$@"
 
 run() {
@@ -46,7 +53,7 @@ get_detect() {
     CURRENT_VERSION=$( <$VERSION_FILE_DESTINATION )
   fi
 
-  curl -o $VERSION_FILE_DESTINATION https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
+  curl $DETECT_CURL_OPTS -o $VERSION_FILE_DESTINATION https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
   LATEST_VERSION=$( <$VERSION_FILE_DESTINATION )
 
   if [ $DETECT_USE_SNAPSHOT -eq 1 ]; then
@@ -71,7 +78,7 @@ get_detect() {
 
   if [ $USE_REMOTE -eq 1 ]; then
     echo "getting ${DETECT_SOURCE} from remote"
-    curl -o $DETECT_DESTINATION https://blackducksoftware.github.io/hub-detect/$DETECT_SOURCE
+    curl $DETECT_CURL_OPTS -o $DETECT_DESTINATION https://blackducksoftware.github.io/hub-detect/$DETECT_SOURCE
     echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}"
   fi
 }

--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -32,13 +32,6 @@ DETECT_JAR_PATH=${DETECT_JAR_PATH:-/tmp}
 
 DETECT_JAVA_OPTS=${DETECT_JAVA_OPTS:-}
 
-# If you want to pass any additional options to
-# curl, specify DETECT_CURL_OPTS in your environment.
-# For exmaple, to specify a proxy, you would set
-# DETECT_CURL_OPTS=--proxy http://myproxy:3128
-
-DETECT_CURL_OPTS=${DETECT_CURL_OPTS:-}
-
 SCRIPT_ARGS="$@"
 
 run() {
@@ -53,7 +46,7 @@ get_detect() {
     CURRENT_VERSION=$( <$VERSION_FILE_DESTINATION )
   fi
 
-  curl $DETECT_CURL_OPTS -o $VERSION_FILE_DESTINATION https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
+  curl -o $VERSION_FILE_DESTINATION https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
   LATEST_VERSION=$( <$VERSION_FILE_DESTINATION )
 
   if [ $DETECT_USE_SNAPSHOT -eq 1 ]; then
@@ -78,7 +71,7 @@ get_detect() {
 
   if [ $USE_REMOTE -eq 1 ]; then
     echo "getting ${DETECT_SOURCE} from remote"
-    curl $DETECT_CURL_OPTS -o $DETECT_DESTINATION https://blackducksoftware.github.io/hub-detect/$DETECT_SOURCE
+    curl -o $DETECT_DESTINATION https://blackducksoftware.github.io/hub-detect/$DETECT_SOURCE
     echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}"
   fi
 }


### PR DESCRIPTION
Updated the parsing for line separators to allow unix style files to work on windows and windows style files to work on linux. I used the Java 8 specification equivalent for `\R` for the separators.