### PR TITLE
Airgap refactor

### DIFF
--- a/airgap.gradle
+++ b/airgap.gradle
@@ -58,7 +58,7 @@ task copyApplicationProperties(type: Copy) {
 }
 
 task downloadDockerInspectorScript() {
-    doLast{
+    doLast {
         def dir = new File(dockerAirGapPath)
         dir.mkdir()
         def dockerInspectorScript = new File(dockerAirGapPath, 'hub-docker-inspector.sh')
@@ -102,16 +102,16 @@ task downloadDockerImages() {
 
 task downloadDockerInspector() {
     dependsOn downloadDockerImages
-    doLast{
-        exec{
+    doLast {
+        exec {
             commandLine 'bash', "${dockerAirGapPath}/hub-docker-inspector.sh", '--pulljar'
         }
-        copy{
+        copy {
             from '.'
             include 'hub-docker-inspector-*.jar'
             into dockerAirGapPath
         }
-        delete fileTree('.'){
+        delete fileTree('.') {
             include 'hub-docker-inspector-*.jar'
         }
     }

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -121,8 +121,8 @@ task createAirGapZip(type: Zip) {
     dependsOn build, copyApplicationProperties, downloadNugetInspector, copyGradleInspectorAndDependencies, downloadDockerInspector
     from buildArtifactFolder
     include "${rootProject.name}-${version}.jar"
-    include 'packaged-inspectors/*/*'
-    include 'config/*'
+    include 'packaged-inspectors/**'
+    include 'config/**'
     archiveName "${rootProject.name}-${version}-air-gap.zip"
     destinationDir(file(buildArtifactFolder))
 }

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -1,0 +1,55 @@
+import java.io.File
+
+final String buildArtifactFolder = "${buildDir}/libs"
+final String airGapFolder = "${buildArtifactFolder}/airgap"
+final String gradleAirGapPath = "${airGapFolder}/gradle/"
+final String nugetAirGapPath = "${airGapFolder}/nuget/"
+final String configAirGapPath = "${buildArtifactFolder}/config/"
+final String dockerAirGapPath = "${airGapFolder}/docker/"
+
+configurations {
+    airGap
+}
+
+dependencies {
+    airGap "com.blackducksoftware.integration:integration-gradle-inspector:+"
+}
+
+void fetchFile(File outputFile, String url) {
+    if (outputFile.exists()) {
+        return
+    }
+    if (!outputFile.getParentFile().exists()) {
+        outputFile.getParentFile().mkdirs()
+    }
+    new URL(url).withInputStream{ i -> outputFile.withOutputStream{ it << i }}
+}
+
+task downloadNugetInspector {
+    doLast {
+        final def nugetInspectorUrl = "https://www.nuget.org/api/v2/package/IntegrationNugetInspector/"
+        fetchFile(new File(nugetAirGapPath, "integrationnugetinspector.nupkg"), nugetInspectorUrl)
+    }
+}
+
+task copyGradleInspectorAndDependencies(type: Copy) {
+    from configurations.airGap
+    include '*.jar'
+    into gradleAirGapPath
+}
+
+task copyApplicationProperties(type: Copy) {
+    from 'src/main/resources/'
+    include 'application.properties'
+    into configAirGapPath
+}
+
+task createAirGapZip(type: Zip) {
+    dependsOn downloadNugetInspector, copyGradleInspectorAndDependencies, copyApplicationProperties, build
+    from buildArtifactFolder
+    include "${rootProject.name}-${version}.jar"
+    include 'airgap/*/*'
+    include 'config/*'
+    archiveName "${rootProject.name}-${version}-air-gap.zip"
+    destinationDir(file(buildArtifactFolder))
+}

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    airGap "com.blackducksoftware.integration:integration-gradle-inspector:+"
+    airGap "com.blackducksoftware.integration:integration-gradle-inspector:latest.release"
 }
 
 void fetchFile(File outputFile, String url) {

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -44,8 +44,45 @@ task copyApplicationProperties(type: Copy) {
     into configAirGapPath
 }
 
+task downloadDockerImages() {
+    doLast {
+        def dir = new File(dockerAirGapPath)
+        dir.mkdir()
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:3.0.0"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:3.0.0"
+        }
+        
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:3.0.0"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:3.0.0"
+        }
+        
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:3.0.0"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:3.0.0"
+        }
+    }
+}
+
+task downloadDockerInspector() {
+    dependsOn downloadDockerImages
+    doLast {
+        final def dockerInspectorJarUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.jar"
+        fetchFile(new File(dockerAirGapPath, "hub-docker-inspector.jar"), dockerInspectorJarUrl)
+        final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.sh"
+        fetchFile(new File(dockerAirGapPath, "hub-docker-inspector.sh"), dockerInspectorScriptUrl)
+    }
+}
+
 task createAirGapZip(type: Zip) {
-    dependsOn downloadNugetInspector, copyGradleInspectorAndDependencies, copyApplicationProperties, build
+    dependsOn build, copyApplicationProperties, downloadNugetInspector, copyGradleInspectorAndDependencies, downloadDockerInspector
     from buildArtifactFolder
     include "${rootProject.name}-${version}.jar"
     include 'airgap/*/*'

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -32,6 +32,13 @@ task downloadNugetInspector {
     }
 }
 
+task downloadGradleInspectorMavenMetadata {
+    doLast {
+        final def gradleInspectorMavenMetadataUrl = "http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml"
+        fetchFile(new File(gradleAirGapPath, "maven-metadata.xml"), gradleInspectorMavenMetadataUrl)
+    }
+}
+
 task copyGradleInspectorAndDependencies(type: Copy) {
     from configurations.airGap
     include '*.jar'

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -28,7 +28,12 @@ void fetchFile(File outputFile, String url) {
 task downloadNugetInspector {
     doLast {
         final def nugetInspectorUrl = 'https://www.nuget.org/api/v2/package/IntegrationNugetInspector/'
-        fetchFile(new File(nugetAirGapPath, 'integrationnugetinspector.nupkg'), nugetInspectorUrl)
+        final def nugetInspectorFile = new File(nugetAirGapPath, 'integrationnugetinspector.nupkg')
+        fetchFile(nugetInspectorFile, nugetInspectorUrl)
+        copy {
+            from zipTree(nugetInspectorFile)
+            into new File(nugetAirGapPath)
+        }
     }
 }
 

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -1,11 +1,11 @@
 import java.io.File
 
 final String buildArtifactFolder = "${buildDir}/libs"
-final String airGapFolder = "${buildArtifactFolder}/airgap"
-final String gradleAirGapPath = "${airGapFolder}/gradle/"
-final String nugetAirGapPath = "${airGapFolder}/nuget/"
-final String configAirGapPath = "${buildArtifactFolder}/config/"
-final String dockerAirGapPath = "${airGapFolder}/docker/"
+final String airGapFolder = "${buildArtifactFolder}/packaged-inspectors"
+final String gradleAirGapPath = "${airGapFolder}/gradle"
+final String nugetAirGapPath = "${airGapFolder}/nuget"
+final String configAirGapPath = "${buildArtifactFolder}/config"
+final String dockerAirGapPath = "${airGapFolder}/docker"
 
 configurations {
     airGap
@@ -49,40 +49,51 @@ task downloadDockerImages() {
         def dir = new File(dockerAirGapPath)
         dir.mkdir()
         exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:3.0.0"
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:latest"
         }
         exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:3.0.0"
-        }
-        
-        exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:3.0.0"
-        }
-        exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:3.0.0"
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:latest"
         }
         
         exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:3.0.0"
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:latest"
         }
         exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:3.0.0"
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:latest"
+        }
+        
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:latest"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:latest"
         }
     }
 }
 
-task downloadDockerInspector() {
-    dependsOn downloadDockerImages
-    doLast {
-        def dockerInspectorJar = new File(dockerAirGapPath, "hub-docker-inspector.jar")
-        final def dockerInspectorJarUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.jar"
-        fetchFile(dockerInspectorJar, dockerInspectorJarUrl)
-        dockerInspectorJar.setExecutable(true)
-        
+task downloadDockerInspectorScript() {
+    doLast{
         def dockerInspectorScript = new File(dockerAirGapPath, "hub-docker-inspector.sh")
-        final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.sh"
-        fetchFile(dockerInspectorScript, dockerInspectorScriptUrl)
+        final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector.sh"
+        fetchFile(dockerInspectorScript, dockerInspectorScriptUrl)              
         dockerInspectorScript.setExecutable(true)
+    }
+}
+
+task downloadDockerInspector() {
+    dependsOn downloadDockerImages, downloadDockerInspectorScript
+    doLast{
+        exec{
+            commandLine "bash", "${dockerAirGapPath}/hub-docker-inspector.sh", "--pulljar"
+        }
+        copy{
+            from '.'
+            include 'hub-docker-inspector-*.jar'
+            into dockerAirGapPath
+        }
+        delete fileTree('.'){
+            include 'hub-docker-inspector-*.jar'
+        }
     }
 }
 
@@ -90,7 +101,7 @@ task createAirGapZip(type: Zip) {
     dependsOn build, copyApplicationProperties, downloadNugetInspector, copyGradleInspectorAndDependencies, downloadDockerInspector
     from buildArtifactFolder
     include "${rootProject.name}-${version}.jar"
-    include 'airgap/*/*'
+    include 'packaged-inspectors/*/*'
     include 'config/*'
     archiveName "${rootProject.name}-${version}-air-gap.zip"
     destinationDir(file(buildArtifactFolder))

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    airGap "com.blackducksoftware.integration:integration-gradle-inspector:latest.release"
+    airGap 'com.blackducksoftware.integration:integration-gradle-inspector:latest.release'
 }
 
 void fetchFile(File outputFile, String url) {
@@ -22,20 +22,20 @@ void fetchFile(File outputFile, String url) {
     if (!outputFile.getParentFile().exists()) {
         outputFile.getParentFile().mkdirs()
     }
-    new URL(url).withInputStream{ i -> outputFile.withOutputStream{ it << i }}
+    new URL(url).withInputStream{ inputStream -> outputFile.withOutputStream{ it << inputStream }}
 }
 
 task downloadNugetInspector {
     doLast {
-        final def nugetInspectorUrl = "https://www.nuget.org/api/v2/package/IntegrationNugetInspector/"
-        fetchFile(new File(nugetAirGapPath, "integrationnugetinspector.nupkg"), nugetInspectorUrl)
+        final def nugetInspectorUrl = 'https://www.nuget.org/api/v2/package/IntegrationNugetInspector/'
+        fetchFile(new File(nugetAirGapPath, 'integrationnugetinspector.nupkg'), nugetInspectorUrl)
     }
 }
 
 task downloadGradleInspectorMavenMetadata {
     doLast {
-        final def gradleInspectorMavenMetadataUrl = "http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml"
-        fetchFile(new File(gradleAirGapPath, "maven-metadata.xml"), gradleInspectorMavenMetadataUrl)
+        final def gradleInspectorMavenMetadataUrl = 'http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml'
+        fetchFile(new File(gradleAirGapPath, 'maven-metadata.xml'), gradleInspectorMavenMetadataUrl)
     }
 }
 
@@ -56,8 +56,8 @@ task downloadDockerInspectorScript() {
     doLast{
         def dir = new File(dockerAirGapPath)
         dir.mkdir()
-        def dockerInspectorScript = new File(dockerAirGapPath, "hub-docker-inspector.sh")
-        final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector.sh"
+        def dockerInspectorScript = new File(dockerAirGapPath, 'hub-docker-inspector.sh')
+        final def dockerInspectorScriptUrl = 'https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector.sh'
         fetchFile(dockerInspectorScript, dockerInspectorScriptUrl)              
         dockerInspectorScript.setExecutable(true)
     }
@@ -68,29 +68,29 @@ task downloadDockerImages() {
     doLast {
         def versionOutputStream = new ByteArrayOutputStream()
         exec {
-            commandLine "bash", "${dockerAirGapPath}/hub-docker-inspector.sh", "--version"
+            commandLine 'bash', "${dockerAirGapPath}/hub-docker-inspector.sh", '--version'
             standardOutput = versionOutputStream
         }
         def versionString = versionOutputStream.toString().trim().split(" ")[1]
         exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
+            commandLine 'docker', 'pull', "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
         }
         exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
-        }
-        
-        exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:${versionString}"
-        }
-        exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:${versionString}"
+            commandLine 'docker', 'save', '-o', "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
         }
         
         exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
+            commandLine 'docker', 'pull', "blackducksoftware/hub-docker-inspector-centos:${versionString}"
         }
         exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
+            commandLine 'docker', 'save', '-o', "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:${versionString}"
+        }
+        
+        exec {
+            commandLine 'docker', 'pull', "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
+        }
+        exec {
+            commandLine 'docker', 'save', '-o', "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
         }
     }
 }
@@ -99,7 +99,7 @@ task downloadDockerInspector() {
     dependsOn downloadDockerImages
     doLast{
         exec{
-            commandLine "bash", "${dockerAirGapPath}/hub-docker-inspector.sh", "--pulljar"
+            commandLine 'bash', "${dockerAirGapPath}/hub-docker-inspector.sh", '--pulljar'
         }
         copy{
             from '.'

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -40,6 +40,7 @@ task downloadGradleInspectorMavenMetadata {
 }
 
 task copyGradleInspectorAndDependencies(type: Copy) {
+    dependsOn downloadGradleInspectorMavenMetadata
     from configurations.airGap
     include '*.jar'
     into gradleAirGapPath
@@ -51,35 +52,10 @@ task copyApplicationProperties(type: Copy) {
     into configAirGapPath
 }
 
-task downloadDockerImages() {
-    doLast {
-        def dir = new File(dockerAirGapPath)
-        dir.mkdir()
-        exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:latest"
-        }
-        exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:latest"
-        }
-        
-        exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:latest"
-        }
-        exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:latest"
-        }
-        
-        exec {
-            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:latest"
-        }
-        exec {
-            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:latest"
-        }
-    }
-}
-
 task downloadDockerInspectorScript() {
     doLast{
+        def dir = new File(dockerAirGapPath)
+        dir.mkdir()
         def dockerInspectorScript = new File(dockerAirGapPath, "hub-docker-inspector.sh")
         final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector.sh"
         fetchFile(dockerInspectorScript, dockerInspectorScriptUrl)              
@@ -87,8 +63,40 @@ task downloadDockerInspectorScript() {
     }
 }
 
+task downloadDockerImages() {
+    dependsOn downloadDockerInspectorScript
+    doLast {
+        def versionOutputStream = new ByteArrayOutputStream()
+        exec {
+            commandLine "bash", "${dockerAirGapPath}/hub-docker-inspector.sh", "--version"
+            standardOutput = versionOutputStream
+        }
+        def versionString = versionOutputStream.toString().trim().split(" ")[1]
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-ubuntu.tar", "blackducksoftware/hub-docker-inspector-ubuntu:${versionString}"
+        }
+        
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-centos:${versionString}"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-centos.tar", "blackducksoftware/hub-docker-inspector-centos:${versionString}"
+        }
+        
+        exec {
+            commandLine "docker", "pull", "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
+        }
+        exec {
+            commandLine "docker", "save", "-o", "${dockerAirGapPath}/hub-docker-inspector-alpine.tar", "blackducksoftware/hub-docker-inspector-alpine:${versionString}"
+        }
+    }
+}
+
 task downloadDockerInspector() {
-    dependsOn downloadDockerImages, downloadDockerInspectorScript
+    dependsOn downloadDockerImages
     doLast{
         exec{
             commandLine "bash", "${dockerAirGapPath}/hub-docker-inspector.sh", "--pulljar"

--- a/airgap.gradle
+++ b/airgap.gradle
@@ -74,10 +74,15 @@ task downloadDockerImages() {
 task downloadDockerInspector() {
     dependsOn downloadDockerImages
     doLast {
+        def dockerInspectorJar = new File(dockerAirGapPath, "hub-docker-inspector.jar")
         final def dockerInspectorJarUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.jar"
-        fetchFile(new File(dockerAirGapPath, "hub-docker-inspector.jar"), dockerInspectorJarUrl)
+        fetchFile(dockerInspectorJar, dockerInspectorJarUrl)
+        dockerInspectorJar.setExecutable(true)
+        
+        def dockerInspectorScript = new File(dockerAirGapPath, "hub-docker-inspector.sh")
         final def dockerInspectorScriptUrl = "https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-3.0.0.sh"
-        fetchFile(new File(dockerAirGapPath, "hub-docker-inspector.sh"), dockerInspectorScriptUrl)
+        fetchFile(dockerInspectorScript, dockerInspectorScriptUrl)
+        dockerInspectorScript.setExecutable(true)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,7 @@ group = 'com.blackducksoftware.integration'
 // Detect version
 version = '2.0.0-SNAPSHOT'
 
-// Human's must change this here and in DetectProperties for every update
-final String gradleInspectorVersion = '0.2.2'
-final String nugetInspectorVersion = '2.0.0'
-
-final String buildArtifactFolder = "${buildDir}/libs/"
-final String gradleAirGapPath = "${buildArtifactFolder}/gradleJars"
-
+apply from: 'airgap.gradle'
 
 // BuildInfo - A json payload usable by detect for information from the build
 JsonBuilder jsonBuilder = new JsonBuilder()
@@ -56,8 +50,6 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 build {
-    finalizedBy 'updateAirGapDependencies'
-
     doLast {
         def shellScriptTemplateFile = new File("${projectDir}/src/main/resources/hub-detect-sh")
         def shellScriptContents = shellScriptTemplateFile.getText('UTF-8')
@@ -80,10 +72,6 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
-configurations {
-    airGapConfig
-}
-
 dependencies {
     compile 'com.blackducksoftware.integration:hub-common:17.0.0'
     compile 'org.springframework.boot:spring-boot-starter'
@@ -96,8 +84,6 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.0'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.0'
-
-    airGapConfig "com.blackducksoftware.integration:integration-gradle-inspector:${gradleInspectorVersion}"
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
@@ -118,30 +104,3 @@ license {
 
 tasks.licenseMain.dependsOn(licenseFormatMain)
 
-void fetchFile(File outputFile, String url) {
-    if (outputFile.exists()) {
-        return
-    }
-    if (!outputFile.getParentFile().exists()) {
-        outputFile.getParentFile().mkdirs()
-    }
-    new URL(url).withInputStream{ i -> outputFile.withOutputStream{ it << i }}
-}
-
-task zipGradleAirGapDependencies(type: Zip) {
-	from configurations.airGapConfig
-	include '*.jar'
-	archiveName "GradleInspectorAirGap_${gradleInspectorVersion}.zip"
-	destinationDir(file(buildArtifactFolder))
-}
-
-task downloadNugetAirGapDependencies {
-    doLast {
-        final def nugetInspectorUrl = "https://www.nuget.org/api/v2/package/IntegrationNugetInspector/${nugetInspectorVersion}"
-        fetchFile(new File(buildArtifactFolder, "NugetInspector_${nugetInspectorVersion}.nupkg"), nugetInspectorUrl)
-    }
-}
-
-task updateAirGapDependencies {
-    dependsOn downloadNugetAirGapDependencies, zipGradleAirGapDependencies
-}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/Application.groovy
@@ -23,6 +23,8 @@
 package com.blackducksoftware.integration.hub.detect
 
 import javax.annotation.PostConstruct
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -174,5 +176,12 @@ class Application {
         configuration.setLogTemplateExceptions(true)
 
         configuration
+    }
+
+    @Bean
+    DocumentBuilder xmlDocumentBuilder() {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance()
+
+        factory.newDocumentBuilder()
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -162,11 +162,12 @@ class DetectConfiguration {
     }
 
     public String guessDetectJarLocation() {
-        String containsDetectJarRegex = "hub-detect-[^\\\\/]+\\.jar"
+        String containsDetectJarRegex = ".*hub-detect-[^\\\\/]+\\.jar.*"
         String javaClassPath = System.getProperty("java.class.path")
         if(javaClassPath?.matches(containsDetectJarRegex)) {
             for(String classPathChunk : javaClassPath.split(System.getProperty("path.separator"))) {
                 if(classPathChunk?.matches(containsDetectJarRegex)) {
+                    logger.trace("Guessed Detect jar location as "+classPathChunk)
                     return classPathChunk
                 }
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -452,12 +452,6 @@ class DetectConfiguration {
     public String getNoticesReportOutputDirectory() {
         return detectProperties.noticesReportOutputDirectory
     }
-    public String getGradleInspectorAirGapPath() {
-        return detectProperties.gradleInspectorAirGapPath?.trim()
-    }
-    public String getNugetInspectorAirGapPath() {
-        return detectProperties.nugetInspectorAirGapPath?.trim()
-    }
     public String getNugetPackagesRepoUrl() {
         return detectProperties.nugetPackagesRepoUrl?.trim()
     }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -187,7 +187,7 @@ class DetectConfiguration {
                 return inspectorAirGapDirectory.getCanonicalPath()
             } catch (final Exception e) {
                 logger.debug("Exception encountered when guessing air gap path for ${inspectorName}, returning the detect property instead")
-                logger.trace(e.getMessage())
+                logger.debug(e.getMessage())
             }
         }
         return inspectorLocationProperty

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -207,7 +207,7 @@ class DetectConfiguration {
                     } else if (fieldName.toLowerCase().contains('gradle') && gradleBomTool.isBomToolApplicable()) {
                         version = gradleBomTool.getInspectorVersion()
                     }
-                    if (version) {
+                    if (version && !'latest'.equalsIgnoreCase(version)) {
                         fieldValue = "latest (${version})" as String
                     }
                 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -398,14 +398,6 @@ class DetectProperties {
     @Value('${detect.conda.environment.name}')
     String condaEnvironmentName
 
-    @ValueDescription(description="The path to the directory containing the air gap dependencies for the gradle inspector", group=DetectProperties.GROUP_GRADLE)
-    @Value('${detect.gradle.inspector.air.gap.path}')
-    String gradleInspectorAirGapPath
-
-    @ValueDescription(description="The path to the nuget inspector nupkg", group=DetectProperties.GROUP_NUGET)
-    @Value('${detect.nuget.inspector.air.gap.path}')
-    String nugetInspectorAirGapPath
-
     @ValueDescription(description="The source for nuget packages", defaultValue='https://www.nuget.org/api/v2/', group=DetectProperties.GROUP_NUGET)
     @Value('${detect.nuget.packages.repo.url}')
     String nugetPackagesRepoUrl

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProperties.groovy
@@ -162,7 +162,7 @@ class DetectProperties {
     @Value('${detect.policy.check}')
     Boolean policyCheck
 
-    @ValueDescription(description="Version of the Gradle Inspector", defaultValue="0.3.0", group=DetectProperties.GROUP_GRADLE)
+    @ValueDescription(description="Version of the Gradle Inspector", defaultValue="latest", group=DetectProperties.GROUP_GRADLE)
     @Value('${detect.gradle.inspector.version}')
     String gradleInspectorVersion
 
@@ -194,7 +194,7 @@ class DetectProperties {
     @Value('${detect.nuget.inspector.name}')
     String nugetInspectorPackageName
 
-    @ValueDescription(description="Version of the Nuget Inspector", defaultValue="2.1.2", group=DetectProperties.GROUP_NUGET)
+    @ValueDescription(description="Version of the Nuget Inspector", defaultValue="latest", group=DetectProperties.GROUP_NUGET)
     @Value('${detect.nuget.inspector.version}')
     String nugetInspectorPackageVersion
 
@@ -397,6 +397,18 @@ class DetectProperties {
     @ValueDescription(description="The name of the anaconda environment used by your project", group=DetectProperties.GROUP_CONDA)
     @Value('${detect.conda.environment.name}')
     String condaEnvironmentName
+
+    @ValueDescription(description="The path to the directory containing the docker inspector script, jar, and images", group=DetectProperties.GROUP_DOCKER)
+    @Value('${detect.docker.inspector.air.gap.path}')
+    String dockerInspectorAirGapPath
+
+    @ValueDescription(description="The path to the directory containing the air gap dependencies for the gradle inspector", group=DetectProperties.GROUP_GRADLE)
+    @Value('${detect.gradle.inspector.air.gap.path}')
+    String gradleInspectorAirGapPath
+
+    @ValueDescription(description="The path to the directory containing the nuget inspector nupkg", group=DetectProperties.GROUP_NUGET)
+    @Value('${detect.nuget.inspector.air.gap.path}')
+    String nugetInspectorAirGapPath
 
     @ValueDescription(description="The source for nuget packages", defaultValue='https://www.nuget.org/api/v2/', group=DetectProperties.GROUP_NUGET)
     @Value('${detect.nuget.packages.repo.url}')

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -220,7 +220,8 @@ class DockerBomTool extends BomTool {
 
     private File getShellScript() {
         File shellScriptFile
-        def airGapHubDockerInspectorShellScript = new File("${detectConfiguration.getDockerInspectorAirGapPath()}", "hub-docker-inspector.sh")
+        def airGapHubDockerInspectorShellScript = new File(detectConfiguration.getDockerInspectorAirGapPath(), "hub-docker-inspector.sh")
+        logger.trace("Verifying air gap shell script present at ${airGapHubDockerInspectorShellScript.getCanonicalPath()}")
 
         if (detectConfiguration.dockerInspectorPath) {
             shellScriptFile = new File(detectConfiguration.dockerInspectorPath)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -93,8 +93,13 @@ class DockerBomTool extends BomTool {
 
     List<DetectCodeLocation> extractDetectCodeLocations() {
         File shellScriptFile
+        def detectJar = new File(System.getProperty('java.class.path'))
+        def airGapHubDockerInspectorShellScript = new File(detectJar.getParentFile(), "/airgap/docker/hub-docker-inspector.sh")
+
         if (detectConfiguration.dockerInspectorPath) {
             shellScriptFile = new File(detectConfiguration.dockerInspectorPath)
+        } else if (airGapHubDockerInspectorShellScript.exists()) {
+            shellScriptFile = airGapHubDockerInspectorShellScript
         } else {
             URL hubDockerInspectorShellScriptUrl = LATEST_URL
             if (!'latest'.equals(detectConfiguration.dockerInspectorVersion)) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -154,18 +154,16 @@ class DockerBomTool extends BomTool {
 
         List<String> bashArguments = [
             "-c",
-            "${shellScriptFile.absolutePath} --spring.config.location=\"${dockerBomToolDirectory.getAbsolutePath()}\" --dry.run=true --no.prompt=true ${imageArgument}" as String
+            "\"${shellScriptFile.absolutePath}\" --spring.config.location=\"${dockerBomToolDirectory.getAbsolutePath()}\" --dry.run=true --no.prompt=true ${imageArgument}" as String
         ]
         if (airGap) {
             def airGapHubDockerInspectorJar = new File(detectJar.getParentFile(), "/airgap/docker/hub-docker-inspector.jar")
-            bashArguments.add((String) "--jar.path=${airGapHubDockerInspectorJar.getAbsolutePath()}")
+            bashArguments[1] = "\"${shellScriptFile.absolutePath}\" --spring.config.location=\"${dockerBomToolDirectory.getAbsolutePath()}\" --dry.run=true --no.prompt=true --jar.path=\"${airGapHubDockerInspectorJar.getAbsolutePath()}\" ${imageArgument}" as String
             for ( String os : ["ubuntu", "alpine", "centos"]) {
+                def dockerImage = new File(airGapHubDockerInspectorJar.getParentFile(), "hub-docker-inspector-${os}.tar")
                 List<String> dockerImportArguments = [
                     "-c",
-                    "docker",
-                    "import",
-                    "airgap/docker/hub-docker-inspector-${os}.tar" as String,
-                    "blackducksoftware/hub-docker-inspector-${os}:3.0.0" as String
+                    "docker load -i \"${dockerImage.getAbsolutePath()}\"" as String
                 ]
                 Executable dockerImportImageExecutable = new Executable(dockerBomToolDirectory, environmentVariables, bashExecutablePath, dockerImportArguments)
                 executableRunner.execute(dockerImportImageExecutable)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -131,16 +131,16 @@ class DockerBomTool extends BomTool {
         Map<String, String> environmentVariables = [PATH: path]
 
         List<String> bashArguments = [
-            "-c",
+            '-c',
             "\"${dockerInspectorShellScript.getCanonicalPath()}\" --spring.config.location=\"${dockerBomToolDirectory.getCanonicalPath()}\" --dry.run=true --no.prompt=true ${imageArgument}" as String
         ]
         def airGapHubDockerInspectorJar = new File("${detectConfiguration.getDockerInspectorAirGapPath()}", "hub-docker-inspector-${inspectorVersion}.jar")
         if(airGapHubDockerInspectorJar.exists()) {
             try {
-                for ( String os : ["ubuntu", "alpine", "centos"]) {
+                for ( String os : ['ubuntu', 'alpine', 'centos']) {
                     def dockerImage = new File(airGapHubDockerInspectorJar.getParentFile(), "hub-docker-inspector-${os}.tar")
                     List<String> dockerImportArguments = [
-                        "-c",
+                        '-c',
                         "docker load -i \"${dockerImage.getCanonicalPath()}\"" as String
                     ]
                     bashArguments[1] = "\"${dockerInspectorShellScript.getCanonicalPath()}\" --spring.config.location=\"${dockerBomToolDirectory.getCanonicalPath()}\" --dry.run=true --no.prompt=true --jar.path=\"${airGapHubDockerInspectorJar.getCanonicalPath()}\" ${imageArgument}" as String
@@ -148,8 +148,8 @@ class DockerBomTool extends BomTool {
                     executableRunner.execute(dockerImportImageExecutable)
                 }
             } catch (Exception e) {
-                logger.trace("Exception encountered when resolving paths for docker air gap, running in online mode instead")
-                logger.trace(e.getMessage())
+                logger.debug('Exception encountered when resolving paths for docker air gap, running in online mode instead')
+                logger.debug(e.getMessage())
             }
         }
         Executable dockerExecutable = new Executable(dockerBomToolDirectory, environmentVariables, bashExecutablePath, bashArguments)
@@ -205,12 +205,12 @@ class DockerBomTool extends BomTool {
                     dockerInspectorShellScript = getShellScript()
                 }
                 List<String> bashArguments = [
-                    "-c",
+                    '-c',
                     "\"${dockerInspectorShellScript.getCanonicalPath()}\" --version" as String
                 ]
                 Executable getDockerInspectorVersion = new Executable(dockerBomToolDirectory, bashExecutablePath, bashArguments)
 
-                inspectorVersion = executableRunner.execute(getDockerInspectorVersion).standardOutput.split(" ")[1]
+                inspectorVersion = executableRunner.execute(getDockerInspectorVersion).standardOutput.split(' ')[1]
             }
         } else {
             inspectorVersion = detectConfiguration.getDockerInspectorVersion()
@@ -220,8 +220,8 @@ class DockerBomTool extends BomTool {
 
     private File getShellScript() {
         File shellScriptFile
-        def airGapHubDockerInspectorShellScript = new File(detectConfiguration.getDockerInspectorAirGapPath(), "hub-docker-inspector.sh")
-        logger.trace("Verifying air gap shell script present at ${airGapHubDockerInspectorShellScript.getCanonicalPath()}")
+        def airGapHubDockerInspectorShellScript = new File(detectConfiguration.getDockerInspectorAirGapPath(), 'hub-docker-inspector.sh')
+        logger.debug("Verifying air gap shell script present at ${airGapHubDockerInspectorShellScript.getCanonicalPath()}")
 
         if (detectConfiguration.dockerInspectorPath) {
             shellScriptFile = new File(detectConfiguration.dockerInspectorPath)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -127,9 +127,9 @@ class DockerBomTool extends BomTool {
             "\"${dockerInspectorShellScript.getCanonicalPath()}\" --spring.config.location=\"${dockerBomToolDirectory.getCanonicalPath()}\" --dry.run=true --no.prompt=true ${imageArgument}" as String
         ]
         def airGapHubDockerInspectorJar = new File("${detectConfiguration.getDockerInspectorAirGapPath()}", "hub-docker-inspector-${dockerInspectorManager.getInspectorVersion(bashExecutablePath)}.jar")
-        if(airGapHubDockerInspectorJar.exists()) {
+        if (airGapHubDockerInspectorJar.exists()) {
             try {
-                for ( String os : ['ubuntu', 'alpine', 'centos']) {
+                for (String os : ['ubuntu', 'alpine', 'centos']) {
                     def dockerImage = new File(airGapHubDockerInspectorJar.getParentFile(), "hub-docker-inspector-${os}.tar")
                     List<String> dockerImportArguments = [
                         '-c',

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -103,9 +103,13 @@ class GradleBomTool extends BomTool {
             'excludedConfigurationNames' : detectConfiguration.getGradleExcludedConfigurationNames(),
             'includedConfigurationNames' : detectConfiguration.getGradleIncludedConfigurationNames()
         ]
-        if (detectConfiguration.getGradleInspectorAirGapPath()) {
-            model.put('airGapLibsPath', new File(detectConfiguration.getGradleInspectorAirGapPath()).getCanonicalPath())
+
+        def detectJar = new File(System.getProperty('java.class.path'))
+        def airGapGradleInspectorDir = new File(detectJar.getParentFile(), "/airgap/gradle/")
+        if (airGapGradleInspectorDir.exists()) {
+            model.put('airGapLibsPath', airGapGradleInspectorDir.getCanonicalPath())
         }
+
         if (detectConfiguration.getGradleInspectorRepositoryUrl()) {
             model.put('customRepositoryUrl', detectConfiguration.getGradleInspectorRepositoryUrl())
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -75,7 +75,6 @@ class GradleBomTool extends BomTool {
         buildGradle && gradleExecutable
     }
 
-
     @Override
     List<DetectCodeLocation> extractDetectCodeLocations(DetectProject detectProject) {
         List<DetectCodeLocation> codeLocations = extractCodeLocationsFromGradle(detectProject)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -23,7 +23,6 @@
 package com.blackducksoftware.integration.hub.detect.bomtool
 
 import javax.xml.parsers.DocumentBuilder
-import javax.xml.parsers.DocumentBuilderFactory
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -61,6 +60,9 @@ class GradleBomTool extends BomTool {
     @Autowired
     GradleDependenciesParser gradleDependenciesParser
 
+    @Autowired
+    DocumentBuilder xmlDocumentBuilder
+
     private String gradleExecutable
     private String inspectorVersion
     private String initScriptPath
@@ -89,23 +91,21 @@ class GradleBomTool extends BomTool {
             if (!inspectorVersion) {
                 try {
                     InputStream inputStream
-                    File airGapMavenMetadataFile = new File(detectConfiguration.getGradleInspectorAirGapPath(), "maven-metadata.xml")
+                    File airGapMavenMetadataFile = new File(detectConfiguration.getGradleInspectorAirGapPath(), 'maven-metadata.xml')
                     if (airGapMavenMetadataFile.exists()) {
                         inputStream = new FileInputStream(airGapMavenMetadataFile)
                     } else {
-                        URL mavenMetadataUrl = new URL("http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml")
+                        URL mavenMetadataUrl = new URL('http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml')
                         inputStream = mavenMetadataUrl.openStream()
                     }
-                    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance()
-                    final DocumentBuilder builder = factory.newDocumentBuilder()
-                    final Document document = builder.parse(inputStream)
-                    final NodeList latestVersionNodes = document.getElementsByTagName("latest")
-                    Node latestVersion = latestVersionNodes.item(0)
+                    final Document xmlDocument = xmlDocumentBuilder.parse(inputStream)
+                    final NodeList latestVersionNodes = xmlDocument.getElementsByTagName('latest')
+                    final Node latestVersion = latestVersionNodes.item(0)
                     inspectorVersion = latestVersion.getTextContent()
                 } catch (Exception e) {
                     inspectorVersion = detectConfiguration.getGradleInspectorVersion()
-                    logger.trace("Execption encountered when resolving latest version of Gradle Inspector, skipping resolution.")
-                    logger.trace(e.getMessage())
+                    logger.debug('Execption encountered when resolving latest version of Gradle Inspector, skipping resolution.')
+                    logger.debug(e.getMessage())
                 }
             }
         } else {
@@ -156,8 +156,8 @@ class GradleBomTool extends BomTool {
                     model.put('airGapLibsPath', gradleInspectorAirGapDirectory.getCanonicalPath())
                 }
             } catch (Exception e) {
-                logger.trace("Exception encountered when resolving air gap path for gradle, running in online mode instead")
-                logger.trace(e.getMessage())
+                logger.debug('Exception encountered when resolving air gap path for gradle, running in online mode instead')
+                logger.debug(e.getMessage())
             }
 
             if (detectConfiguration.getGradleInspectorRepositoryUrl()) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -174,13 +174,18 @@ class NugetBomTool extends BomTool {
             ])
         } else {
             logger.debug('Running online. Resolving through nuget')
+            if (!'latest'.equalsIgnoreCase(detectConfiguration.getNugetInspectorPackageVersion())) {
+                nugetOptions.addAll([
+                    '-Version',
+                    detectConfiguration.getNugetInspectorPackageVersion()
+                ])
+            }
             nugetOptions.addAll([
-                '-Version',
-                detectConfiguration.getNugetInspectorPackageVersion(),
                 '-Source',
                 detectConfiguration.getNugetPackagesRepoUrl()
             ])
         }
+
 
         if (!inspectorExe.exists()) {
             Executable installInspectorExecutable = new Executable(detectConfiguration.sourceDirectory, nugetExecutable, nugetOptions)

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -78,8 +78,10 @@ class NugetBomTool extends BomTool {
 
     @Override
     List<DetectCodeLocation> extractDetectCodeLocations() {
+        nugetInspectorManager.installInspector(nugetExecutable, outputDirectory);
+
         if (!nugetInspectorManager.getNugetInspectorExecutablePath()) {
-            return []
+            throw new Exception("Failed to find a suitable nuget inspector to run.");
         }
 
         List<String> options =  [

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -78,13 +78,13 @@ class NugetBomTool extends BomTool {
 
     @Override
     List<DetectCodeLocation> extractDetectCodeLocations() {
-        nugetInspectorManager.installInspector(nugetExecutable, outputDirectory);
+        nugetInspectorManager.installInspector(nugetExecutable, outputDirectory)
 
         if (!nugetInspectorManager.getNugetInspectorExecutablePath()) {
-            throw new Exception("Failed to find a suitable nuget inspector to run.");
+            throw new Exception("Failed to find a suitable nuget inspector to run.")
         }
 
-        List<String> options =  [
+        List<String> options = [
             "--target_path=${sourcePath}" as String,
             "--output_directory=${outputDirectory.getCanonicalPath()}" as String,
             "--ignore_failure=${detectConfiguration.getNugetInspectorIgnoreFailure()}" as String
@@ -95,7 +95,7 @@ class NugetBomTool extends BomTool {
         if (detectConfiguration.getNugetPackagesRepoUrl()) {
             options.add("--packages_repo_url=${detectConfiguration.getNugetPackagesRepoUrl()}" as String)
         }
-        if (logger.traceEnabled) {
+        if (logger.isTraceEnabled()) {
             options.add('-v')
         }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -125,7 +125,7 @@ class NugetBomTool extends BomTool {
                 ]
                 def airGapNugetInspectorDirectory = new File(detectConfiguration.getNugetInspectorAirGapPath())
                 if (airGapNugetInspectorDirectory.exists()) {
-                    logger.debug("Running in airgap mode. Resolving version from local path")
+                    logger.debug('Running in airgap mode. Resolving version from local path')
                     nugetOptions.addAll([
                         '-Source',
                         detectConfiguration.getNugetInspectorAirGapPath()
@@ -141,7 +141,7 @@ class NugetBomTool extends BomTool {
 
                 List<String> output = executableRunner.execute(getInspectorVersionExecutable).standardOutputAsList
                 for (String line : output) {
-                    String[] lineChunks = line.split(" ")
+                    String[] lineChunks = line.split(' ')
                     if (detectConfiguration.getNugetInspectorPackageName()?.equalsIgnoreCase(lineChunks[0])) {
                         return lineChunks[1]
                     }
@@ -167,7 +167,7 @@ class NugetBomTool extends BomTool {
 
         def airGapNugetInspectorDirectory = new File(detectConfiguration.getNugetInspectorAirGapPath())
         if (airGapNugetInspectorDirectory.exists()) {
-            logger.debug("Running in airgap mode. Resolving from local path")
+            logger.debug('Running in airgap mode. Resolving from local path')
             nugetOptions.addAll([
                 '-Source',
                 detectConfiguration.getNugetInspectorAirGapPath()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NugetBomTool.groovy
@@ -128,9 +128,11 @@ class NugetBomTool extends BomTool {
             outputDirectory.getCanonicalPath()
         ]
 
-        if (detectConfiguration.getNugetInspectorAirGapPath()?.trim()) {
-            logger.debug("Running air gapped with ${detectConfiguration.getNugetInspectorAirGapPath()}")
-            final File nupkgParentDirectory = new File(detectConfiguration.getNugetInspectorAirGapPath()).getParentFile()
+        def detectJar = new File(System.getProperty('java.class.path'))
+        def airGapNugetInspectorDir = new File(detectJar.getParentFile(), "/airgap/nuget/")
+        if (airGapNugetInspectorDir.exists()) {
+            logger.debug("Running in airgap mode. Resolving from local path")
+            final File nupkgParentDirectory = airGapNugetInspectorDir.getParentFile()
             nugetOptions.addAll([
                 '-Source',
                 nupkgParentDirectory.getCanonicalPath()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.groovy
@@ -1,0 +1,106 @@
+package com.blackducksoftware.integration.hub.detect.bomtool.docker
+
+import org.apache.commons.lang3.math.NumberUtils
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import com.blackducksoftware.integration.hub.detect.DetectConfiguration
+import com.blackducksoftware.integration.hub.detect.bomtool.gradle.GradleInspectorManager
+import com.blackducksoftware.integration.hub.detect.model.BomToolType
+import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
+import com.blackducksoftware.integration.hub.detect.util.executable.Executable
+import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
+import com.blackducksoftware.integration.hub.rest.UnauthenticatedRestConnection
+import com.blackducksoftware.integration.log.Slf4jIntLogger
+
+import groovy.transform.TypeChecked
+import okhttp3.HttpUrl
+import okhttp3.Request
+import okhttp3.Response
+
+@Component
+@TypeChecked
+class DockerInspectorManager {
+    private final Logger logger = LoggerFactory.getLogger(GradleInspectorManager.class)
+
+    static final URL LATEST_URL = new URL('https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector.sh')
+
+    @Autowired
+    DetectConfiguration detectConfiguration
+
+    @Autowired
+    DetectFileManager detectFileManager
+
+    @Autowired
+    ExecutableRunner executableRunner
+
+    private File dockerInspectorShellScript
+    private String inspectorVersion
+
+    String getInspectorVersion(String bashExecutablePath) {
+        if ('latest'.equalsIgnoreCase(detectConfiguration.getDockerInspectorVersion())) {
+            if (!inspectorVersion) {
+                File dockerPropertiesFile = detectFileManager.createFile(BomToolType.DOCKER, 'application.properties')
+                File dockerBomToolDirectory =  dockerPropertiesFile.getParentFile()
+                if(!dockerInspectorShellScript) {
+                    dockerInspectorShellScript = getShellScript()
+                }
+                List<String> bashArguments = [
+                    '-c',
+                    "\"${dockerInspectorShellScript.getCanonicalPath()}\" --version" as String
+                ]
+                Executable getDockerInspectorVersion = new Executable(dockerBomToolDirectory, bashExecutablePath, bashArguments)
+
+                inspectorVersion = executableRunner.execute(getDockerInspectorVersion).standardOutput.split(' ')[1]
+            }
+        } else {
+            inspectorVersion = detectConfiguration.getDockerInspectorVersion()
+        }
+        inspectorVersion
+    }
+
+    private File getShellScript() {
+        if (!dockerInspectorShellScript) {
+            File shellScriptFile
+            def airGapHubDockerInspectorShellScript = new File(detectConfiguration.getDockerInspectorAirGapPath(), 'hub-docker-inspector.sh')
+            logger.debug("Verifying air gap shell script present at ${airGapHubDockerInspectorShellScript.getCanonicalPath()}")
+
+            if (detectConfiguration.dockerInspectorPath) {
+                shellScriptFile = new File(detectConfiguration.dockerInspectorPath)
+            } else if (airGapHubDockerInspectorShellScript.exists()) {
+                shellScriptFile = airGapHubDockerInspectorShellScript
+            } else {
+                URL hubDockerInspectorShellScriptUrl = LATEST_URL
+                if (!'latest'.equals(detectConfiguration.dockerInspectorVersion)) {
+                    hubDockerInspectorShellScriptUrl = new URL("https://blackducksoftware.github.io/hub-docker-inspector/hub-docker-inspector-${detectConfiguration.dockerInspectorVersion}.sh")
+                }
+                logger.info("Getting the Docker inspector shell script from ${hubDockerInspectorShellScriptUrl.toURI().toString()}")
+                UnauthenticatedRestConnection restConnection = new UnauthenticatedRestConnection(new Slf4jIntLogger(logger), hubDockerInspectorShellScriptUrl, detectConfiguration.getHubTimeout())
+                restConnection.alwaysTrustServerCertificate = detectConfiguration.hubTrustCertificate
+                restConnection.proxyHost = detectConfiguration.getHubProxyHost()
+                restConnection.proxyPort = NumberUtils.toInt(detectConfiguration.getHubProxyPort())
+                restConnection.proxyUsername = detectConfiguration.getHubProxyUsername()
+                restConnection.proxyPassword = detectConfiguration.getHubProxyPassword()
+                HttpUrl httpUrl = restConnection.createHttpUrl()
+                Request request = restConnection.createGetRequest(httpUrl)
+                String shellScriptContents = null
+                Response response = null
+                try {
+                    response = restConnection.handleExecuteClientCall(request)
+                    shellScriptContents =  response.body().string()
+                } finally {
+                    if (response != null) {
+                        response.close()
+                    }
+                }
+                shellScriptFile = detectFileManager.createFile(BomToolType.DOCKER, "hub-docker-inspector-${detectConfiguration.dockerInspectorVersion}.sh")
+                detectFileManager.writeToFile(shellScriptFile, shellScriptContents)
+                shellScriptFile.setExecutable(true)
+            }
+            dockerInspectorShellScript = shellScriptFile
+        }
+        return dockerInspectorShellScript
+    }
+}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.groovy
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.blackducksoftware.integration.hub.detect.bomtool.docker
 
 import org.apache.commons.lang3.math.NumberUtils

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
@@ -1,0 +1,109 @@
+package com.blackducksoftware.integration.hub.detect.bomtool.gradle
+
+import javax.xml.parsers.DocumentBuilder
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+
+import com.blackducksoftware.integration.hub.detect.DetectConfiguration
+import com.blackducksoftware.integration.hub.detect.model.BomToolType
+import com.blackducksoftware.integration.hub.detect.util.DetectFileManager
+import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
+
+import freemarker.template.Configuration
+import freemarker.template.Template
+import groovy.transform.TypeChecked
+
+@Component
+@TypeChecked
+class GradleInspectorManager {
+    private final Logger logger = LoggerFactory.getLogger(GradleInspectorManager.class)
+
+    @Autowired
+    Configuration configuration
+
+    @Autowired
+    DocumentBuilder xmlDocumentBuilder
+
+    @Autowired
+    DetectConfiguration detectConfiguration
+
+    @Autowired
+    ExecutableRunner executableRunner
+
+    @Autowired
+    DetectFileManager detectFileManager
+
+    private String inspectorVersion
+    private String initScriptPath
+
+    String getInspectorVersion() {
+        if ('latest'.equalsIgnoreCase(detectConfiguration.getGradleInspectorVersion())) {
+            if (!inspectorVersion) {
+                try {
+                    InputStream inputStream
+                    File airGapMavenMetadataFile = new File(detectConfiguration.getGradleInspectorAirGapPath(), 'maven-metadata.xml')
+                    if (airGapMavenMetadataFile.exists()) {
+                        inputStream = new FileInputStream(airGapMavenMetadataFile)
+                    } else {
+                        URL mavenMetadataUrl = new URL('http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml')
+                        inputStream = mavenMetadataUrl.openStream()
+                    }
+                    final Document xmlDocument = xmlDocumentBuilder.parse(inputStream)
+                    final NodeList latestVersionNodes = xmlDocument.getElementsByTagName('latest')
+                    final Node latestVersion = latestVersionNodes.item(0)
+                    inspectorVersion = latestVersion.getTextContent()
+                } catch (Exception e) {
+                    inspectorVersion = detectConfiguration.getGradleInspectorVersion()
+                    logger.debug('Execption encountered when resolving latest version of Gradle Inspector, skipping resolution.')
+                    logger.debug(e.getMessage())
+                }
+            }
+        } else {
+            inspectorVersion = detectConfiguration.getGradleInspectorVersion()
+        }
+        inspectorVersion
+    }
+
+    String getInitScriptPath() {
+        if(!initScriptPath) {
+            File initScriptFile = detectFileManager.createFile(BomToolType.GRADLE, 'init-detect.gradle')
+            String gradleInspectorVersion = detectConfiguration.getGradleInspectorVersion()
+            gradleInspectorVersion = 'latest'.equalsIgnoreCase(gradleInspectorVersion) ? '+' : gradleInspectorVersion
+            final Map<String, String> model = [
+                'gradleInspectorVersion' : gradleInspectorVersion,
+                'excludedProjectNames' : detectConfiguration.getGradleExcludedProjectNames(),
+                'includedProjectNames' : detectConfiguration.getGradleIncludedProjectNames(),
+                'excludedConfigurationNames' : detectConfiguration.getGradleExcludedConfigurationNames(),
+                'includedConfigurationNames' : detectConfiguration.getGradleIncludedConfigurationNames()
+            ]
+
+            try {
+                def gradleInspectorAirGapDirectory = new File(detectConfiguration.getGradleInspectorAirGapPath())
+                if (gradleInspectorAirGapDirectory.exists()) {
+                    model.put('airGapLibsPath', gradleInspectorAirGapDirectory.getCanonicalPath())
+                }
+            } catch (Exception e) {
+                logger.debug('Exception encountered when resolving air gap path for gradle, running in online mode instead')
+                logger.debug(e.getMessage())
+            }
+
+            if (detectConfiguration.getGradleInspectorRepositoryUrl()) {
+                model.put('customRepositoryUrl', detectConfiguration.getGradleInspectorRepositoryUrl())
+            }
+
+            final Template initScriptTemplate = configuration.getTemplate('init-script-gradle.ftl')
+            initScriptFile.withWriter('UTF-8') {
+                initScriptTemplate.process(model, it)
+            }
+
+            initScriptPath = initScriptFile.getCanonicalPath()
+        }
+        return initScriptPath
+    }
+}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.blackducksoftware.integration.hub.detect.bomtool.gradle
 
 import javax.xml.parsers.DocumentBuilder

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.groovy
@@ -93,7 +93,7 @@ class GradleInspectorManager {
     }
 
     String getInitScriptPath() {
-        if(!initScriptPath) {
+        if (!initScriptPath) {
             File initScriptFile = detectFileManager.createFile(BomToolType.GRADLE, 'init-detect.gradle')
             String gradleInspectorVersion = detectConfiguration.getGradleInspectorVersion()
             gradleInspectorVersion = 'latest'.equalsIgnoreCase(gradleInspectorVersion) ? '+' : gradleInspectorVersion

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorManager.groovy
@@ -1,0 +1,117 @@
+package com.blackducksoftware.integration.hub.detect.bomtool.nuget
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import com.blackducksoftware.integration.hub.detect.DetectConfiguration
+import com.blackducksoftware.integration.hub.detect.util.executable.Executable
+import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRunner
+
+import groovy.transform.TypeChecked
+
+@Component
+@TypeChecked
+class NugetInspectorManager {
+    private final Logger logger = LoggerFactory.getLogger(NugetInspectorManager.class)
+
+    private String nugetInspectorExecutable
+    private String inspectorVersion
+
+    @Autowired
+    DetectConfiguration detectConfiguration
+
+    @Autowired
+    ExecutableRunner executableRunner
+
+    public String getNugetInspectorExecutablePath() {
+        return nugetInspectorExecutable
+    }
+
+    public String getInspectorVersion(final String nugetExecutablePath) {
+        if ('latest'.equalsIgnoreCase(detectConfiguration.getNugetInspectorPackageVersion())) {
+            if (!inspectorVersion) {
+                final def nugetOptions = [
+                    'list',
+                    detectConfiguration.getNugetInspectorPackageName()
+                ]
+                def airGapNugetInspectorDirectory = new File(detectConfiguration.getNugetInspectorAirGapPath())
+                if (airGapNugetInspectorDirectory.exists()) {
+                    logger.debug('Running in airgap mode. Resolving version from local path')
+                    nugetOptions.addAll([
+                        '-Source',
+                        detectConfiguration.getNugetInspectorAirGapPath()
+                    ])
+                } else {
+                    logger.debug('Running online. Resolving version through nuget')
+                    nugetOptions.addAll([
+                        '-Source',
+                        detectConfiguration.getNugetPackagesRepoUrl()
+                    ])
+                }
+                Executable getInspectorVersionExecutable = new Executable(detectConfiguration.sourceDirectory, nugetExecutablePath, nugetOptions)
+
+                List<String> output = executableRunner.execute(getInspectorVersionExecutable).standardOutputAsList
+                for (String line : output) {
+                    String[] lineChunks = line.split(' ')
+                    if (detectConfiguration.getNugetInspectorPackageName()?.equalsIgnoreCase(lineChunks[0])) {
+                        return lineChunks[1]
+                    }
+                }
+            }
+        } else {
+            inspectorVersion = detectConfiguration.getDockerInspectorVersion()
+        }
+        return inspectorVersion
+    }
+
+    private String installInspector(final String nugetExecutablePath, final File outputDirectory) {
+        final File inspectorVersionDirectory = new File(outputDirectory, "${detectConfiguration.getNugetInspectorPackageName()}.${detectConfiguration.getNugetInspectorPackageVersion()}")
+        final File toolsDirectory = new File(inspectorVersionDirectory, 'tools')
+        final File inspectorExe = new File(toolsDirectory, "${detectConfiguration.getNugetInspectorPackageName()}.exe")
+
+        final def nugetOptions = [
+            'install',
+            detectConfiguration.getNugetInspectorPackageName(),
+            '-OutputDirectory',
+            outputDirectory.getCanonicalPath()
+        ]
+
+        def airGapNugetInspectorDirectory = new File(detectConfiguration.getNugetInspectorAirGapPath())
+        if (airGapNugetInspectorDirectory.exists()) {
+            logger.debug('Running in airgap mode. Resolving from local path')
+            nugetOptions.addAll([
+                '-Source',
+                detectConfiguration.getNugetInspectorAirGapPath()
+            ])
+        } else {
+            logger.debug('Running online. Resolving through nuget')
+            if (!'latest'.equalsIgnoreCase(detectConfiguration.getNugetInspectorPackageVersion())) {
+                nugetOptions.addAll([
+                    '-Version',
+                    detectConfiguration.getNugetInspectorPackageVersion()
+                ])
+            }
+            nugetOptions.addAll([
+                '-Source',
+                detectConfiguration.getNugetPackagesRepoUrl()
+            ])
+        }
+
+
+        if (!inspectorExe.exists()) {
+            Executable installInspectorExecutable = new Executable(detectConfiguration.sourceDirectory, nugetExecutablePath, nugetOptions)
+            executableRunner.execute(installInspectorExecutable)
+        } else {
+            logger.info("Existing nuget inspector found at ${inspectorExe.getCanonicalPath()}")
+        }
+
+        if (!inspectorExe.exists()) {
+            logger.warn("Could not find the ${detectConfiguration.getNugetInspectorPackageName()} version:${detectConfiguration.getNugetInspectorPackageVersion()} even after an install attempt.")
+            return null
+        }
+
+        inspectorExe.getCanonicalPath()
+    }
+}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorManager.groovy
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.blackducksoftware.integration.hub.detect.bomtool.nuget
 
 import org.slf4j.Logger

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,9 +63,9 @@ detect.maven.path=
 detect.maven.excluded.modules=
 detect.maven.included.modules=
 
-detect.nuget.inspector.air.gap.path=
 detect.nuget.inspector.name=
 detect.nuget.inspector.version=
+detect.nuget.inspector.air.gap.path=
 detect.nuget.packages.repo.url=
 detect.nuget.ignore.failure=
 detect.nuget.excluded.modules=
@@ -73,9 +73,9 @@ detect.nuget.path=
 
 detect.go.dep.path=
 
-detect.docker.inspector.air.gap.path=
 detect.docker.inspector.path=
 detect.docker.inspector.version=
+detect.docker.inspector.air.gap.path=
 detect.docker.tar=
 detect.docker.image=
 detect.docker.path=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,7 @@ detect.default.project.version.timeformat=
 
 detect.policy.check=
 
+detect.gradle.inspector.air.gap.path=
 detect.gradle.inspector.version=
 detect.gradle.inspector.repository.url=
 detect.gradle.path=
@@ -62,6 +63,7 @@ detect.maven.path=
 detect.maven.excluded.modules=
 detect.maven.included.modules=
 
+detect.nuget.inspector.air.gap.path=
 detect.nuget.inspector.name=
 detect.nuget.inspector.version=
 detect.nuget.packages.repo.url=
@@ -71,6 +73,7 @@ detect.nuget.path=
 
 detect.go.dep.path=
 
+detect.docker.inspector.air.gap.path=
 detect.docker.inspector.path=
 detect.docker.inspector.version=
 detect.docker.tar=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,7 +40,6 @@ detect.default.project.version.timeformat=
 detect.policy.check=
 
 detect.gradle.inspector.version=
-detect.gradle.inspector.air.gap.path=
 detect.gradle.inspector.repository.url=
 detect.gradle.path=
 detect.gradle.build.command=
@@ -63,7 +62,6 @@ detect.maven.included.modules=
 
 detect.nuget.inspector.name=
 detect.nuget.inspector.version=
-detect.nuget.inspector.air.gap.path=
 detect.nuget.packages.repo.url=
 detect.nuget.ignore.failure=
 detect.nuget.excluded.modules=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,8 +41,8 @@ detect.default.project.version.timeformat=
 
 detect.policy.check=
 
-detect.gradle.inspector.air.gap.path=
 detect.gradle.inspector.version=
+detect.gradle.inspector.air.gap.path=
 detect.gradle.inspector.repository.url=
 detect.gradle.path=
 detect.gradle.build.command=


### PR DESCRIPTION
The goal here is twofold- one, we want to create a build target for Detect that creates a single archive with all files needed to run Detect in an airgap environment. Two, we want customers to be able to execute in an airgap environment with as few flags as possible.

The airgap.gradle file contains all logic for constructing the archive, and is referenced by the build.gradle, so one can simply create an airgap archive by executing the createAirGapZip target.

The bomtools with inspectors now have unique logic for retrieving the version of the inspector that they use and will default to retrieving and utilizing the "latest" version, if available. If the versioning property is set to latest and the BomTool applies, it will attempt to resolve the actual version of the inspector that it is executing and report it when the detect config is printed like so: "....Version = latest (resolved.version.here)"

If resolution fails or if the BomTool does not apply, it will be printed as "latest"