### PR TITLE
New filename scheme based on external id instead of project name.

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
@@ -198,7 +198,6 @@ class DetectProjectManager implements SummaryResultReporter {
     }
 
     private String generateShortenedFilename(BomToolType bomToolType, String finalSourcePathPiece, ExternalId externalId) {
-
         List<String> filenamePieces = new ArrayList<>();
         filenamePieces.addAll(externalId.getExternalIdPieces());
         filenamePieces.add(finalSourcePathPiece);

--- a/src/test/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManagerTest.groovy
+++ b/src/test/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManagerTest.groovy
@@ -7,10 +7,15 @@ import org.joda.time.format.DateTimeFormat
 import org.junit.Assert
 import org.junit.Test
 
+import com.blackducksoftware.integration.hub.bdio.model.Forge
+import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalId
+import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalIdFactory
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.util.IntegrationEscapeUtil
 
 public class DetectProjectManagerTest {
+    private ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+
     @Test
     void testGettingDefaultProjectVersions() {
         def detectConfiguration = new DetectConfiguration()
@@ -39,7 +44,8 @@ public class DetectProjectManagerTest {
     void testProjectFileName() {
         def detectProjectManager = new DetectProjectManager()
         detectProjectManager.integrationEscapeUtil = new IntegrationEscapeUtil()
-        String actual = detectProjectManager.createBdioFilename(BomToolType.NPM, "test", "short", "name")
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPM, "short", "name");
+        String actual = detectProjectManager.generateShortenedFilename(BomToolType.NPM, "test", externalId)
         String expected = "NPM_short_name_test_bdio.jsonld"
         Assert.assertEquals(expected, actual)
     }
@@ -51,8 +57,35 @@ public class DetectProjectManagerTest {
         String longPath = StringUtils.repeat('a', 250)
         String longVersion = StringUtils.repeat('b', 250)
         String longName = StringUtils.repeat('c', 250)
-        String actual = detectProjectManager.createBdioFilename(BomToolType.NPM, longPath, longName, longVersion)
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPM, longName, longVersion);
+        String actual = detectProjectManager.generateShortenedFilename(BomToolType.NPM, longPath, externalId)
         String expected = "NPM_ec4c72e67030b52_bc7ea19d315b641_b5d5e3e0fcccfb4_bdio.jsonld"
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    void testOrderedProjectLongFileName() {
+        def detectProjectManager = new DetectProjectManager()
+        detectProjectManager.integrationEscapeUtil = new IntegrationEscapeUtil()
+        String longPath = "second"
+        String longVersion = "first"
+        String longName = StringUtils.repeat('c', 250)
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPM, longName, longVersion);
+        String actual = detectProjectManager.generateShortenedFilename(BomToolType.NPM, longPath, externalId)
+        String expected = "NPM_first_second_ec4c72e67030b52_bdio.jsonld"
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    void testOrderedProjectLongFileNameSwitched() {
+        def detectProjectManager = new DetectProjectManager()
+        detectProjectManager.integrationEscapeUtil = new IntegrationEscapeUtil()
+        String longPath = "first"
+        String longVersion = "second"
+        String longName = StringUtils.repeat('c', 250)
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPM, longName, longVersion);
+        String actual = detectProjectManager.generateShortenedFilename(BomToolType.NPM, longPath, externalId)
+        String expected = "NPM_first_second_ec4c72e67030b52_bdio.jsonld"
         Assert.assertEquals(expected, actual)
     }
 }


### PR DESCRIPTION
This makes slightly longer filenames in most cases (group, artifact, version) instead of (artifact, version) but should reduce conflicts. I've also improved the long filename ordering after talking with brian.