### PR TITLE
Phone home bomtool data

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerProperties.groovy
@@ -43,6 +43,7 @@ class DockerProperties {
         dockerProperties.setProperty('output.path', bomToolOutputDirectory.getAbsolutePath())
         dockerProperties.setProperty('output.include.containerfilesystem', 'true')
         dockerProperties.setProperty('logging.level.com.blackducksoftware', detectConfiguration.getLoggingLevel())
+        dockerProperties.setProperty('phone.home', 'false')
 
         detectConfiguration.additionalDockerPropertyNames.each { propertyName ->
             String dockerKey = propertyName[DetectConfiguration.DOCKER_PROPERTY_PREFIX.length()..-1]

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -62,13 +62,11 @@ class BdioUploader {
 
         String hubDetectVersion = detectInfo.detectVersion
         PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeDataService.createInitialPhoneHomeRequestBodyBuilder(ThirdPartyName.DETECT, hubDetectVersion, hubDetectVersion).build()
-        populatePhoneHomeBomToolMetadata(detectProject, phoneHomeRequestBody.getInfoMap());
+
+        Set<BomToolType> applicableBomTools = detectProject.getApplicableBomTools();
+        String applicableBomToolsString = StringUtils.join(applicableBomTools, ", ");
+        phoneHomeRequestBody.getInfoMap().put("bomToolTypes", applicableBomToolsString);
 
         phoneHomeDataService.phoneHome(phoneHomeRequestBody)
-    }
-
-    private String populatePhoneHomeBomToolMetadata(DetectProject detectProject, Map<String, String> metadataMap) {
-        Set<BomToolType> bomToolTypes = detectProject.getApplicableBomTools();
-        metadataMap.put("bomToolTypes", StringUtils.join(bomToolTypes, ", "));
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -36,6 +36,7 @@ import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
 import com.blackducksoftware.integration.hub.global.HubServerConfig
 import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody
+import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBodyBuilder
 import com.blackducksoftware.integration.phonehome.enums.ThirdPartyName
 
 import groovy.transform.TypeChecked
@@ -61,12 +62,13 @@ class BdioUploader {
         }
 
         String hubDetectVersion = detectInfo.detectVersion
-        PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeDataService.createInitialPhoneHomeRequestBodyBuilder(ThirdPartyName.DETECT, hubDetectVersion, hubDetectVersion).build()
-
         Set<BomToolType> applicableBomTools = detectProject.getApplicableBomTools();
         String applicableBomToolsString = StringUtils.join(applicableBomTools, ", ");
-        phoneHomeRequestBody.getInfoMap().put("bomToolTypes", applicableBomToolsString);
 
+        PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = phoneHomeDataService.createInitialPhoneHomeRequestBodyBuilder(ThirdPartyName.DETECT, hubDetectVersion, hubDetectVersion);
+        phoneHomeRequestBodyBuilder.addToMetaDataMap('bomToolTypes', applicableBomToolsString);
+
+        PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
         phoneHomeDataService.phoneHome(phoneHomeRequestBody)
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
@@ -89,7 +89,7 @@ class HubManager implements ExitCodeReporter {
             HubServerConfig hubServerConfig = hubServiceWrapper.hubServerConfig
             BomImportRequestService bomImportRequestService = hubServiceWrapper.createBomImportRequestService()
             PhoneHomeDataService phoneHomeDataService = hubServiceWrapper.createPhoneHomeDataService()
-            bdioUploader.uploadBdioFiles(hubServerConfig, bomImportRequestService, phoneHomeDataService, createdBdioFiles)
+            bdioUploader.uploadBdioFiles(hubServerConfig, bomImportRequestService, phoneHomeDataService, detectProject, createdBdioFiles)
         } else {
             logger.debug('Did not create any bdio files.')
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/DetectProject.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/DetectProject.groovy
@@ -71,6 +71,14 @@ class DetectProject {
         detectCodeLocations.add(detectCodeLocation)
     }
 
+    public Set<BomToolType> getApplicableBomTools() {
+        Set<BomToolType> applicableBomTools = new HashSet<>();
+        for (DetectCodeLocation detectCodeLocation : detectCodeLocations) {
+            applicableBomTools.add(detectCodeLocation.getBomToolType());
+        }
+        return applicableBomTools;
+    }
+
     public List<DetectCodeLocation> getDetectCodeLocations() {
         detectCodeLocations
     }


### PR DESCRIPTION
Now that detect can phone home with the meta data about which bom tools were applicable, docker doesn't need to run its own phone home anymore.