### PR TITLE
Adding Packagist discrepancy logs when composer.json and composer.lock mismatch

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.groovy
@@ -72,24 +72,24 @@ class PackagistParser {
         }
         convertFromJsonToDependency(graph, null, startingPackages, packagistPackages, true)
 
-        packagistPackages.each{
+        packagistPackages.each {
             String packageName = it.getAt('name').toString().replace('"', '')
             String packageVersion = it.getAt('version').toString().replace('"', '')
             ExternalId id = externalIdFactory.createNameVersionExternalId(Forge.PACKAGIST, packageName, packageVersion);
-            if (graph.getDependency(id) == null){
+            if (graph.getDependency(id) == null) {
                 logger.warn("A discrepency exists between the composer.json and the composer.lock - the package '${packageName}' was in the lock but was not included in the json dependency tree.");
             }
         }
 
         List<String> allPackageNames =  packagistPackages.collect{it.getAt('name').toString().replace('"', '')}
         startingPackages.each {
-            if (!allPackageNames.contains(it)){
+            if (!allPackageNames.contains(it)) {
                 logger.warn("A discrepency exists between the composer.json and the composer.lock - the package '${it}' was in the json but not the lock.");
             }
         }
 
         ExternalId projectExternalId;
-        if (projectName == null || projectVersion == null){
+        if (projectName == null || projectVersion == null) {
             projectExternalId = externalIdFactory.createPathExternalId(Forge.PACKAGIST, sourcePath);
         }else{
             projectExternalId = externalIdFactory.createNameVersionExternalId(Forge.PACKAGIST, projectName, projectVersion);
@@ -112,7 +112,7 @@ class PackagistParser {
                 Dependency child = new Dependency(currentRowPackageName, currentRowPackageVersion, externalIdFactory.createNameVersionExternalId(Forge.PACKAGIST, currentRowPackageName, currentRowPackageVersion))
 
                 convertFromJsonToDependency(graph, child, getStartingPackages(it.getAsJsonObject(), false), jsonArray, false)
-                if (root){
+                if (root) {
                     graph.addChildToRoot(child)
                 }else{
                     graph.addParentWithChild(parent, child)


### PR DESCRIPTION
This is the least intrusive way I could find to do this. Minimum modifications. 