### PR TITLE
added the curl options to a curl call that did not have them

### DIFF
--- a/src/main/resources/hub-detect-sh
+++ b/src/main/resources/hub-detect-sh
@@ -58,7 +58,7 @@ get_detect() {
     fi
   else
     if [ -z "${DETECT_RELEASE_VERSION}" ]; then
-      DETECT_RELEASE_VERSION=$(curl 'https://test-repo.blackducksoftware.com/artifactory/api/search/latestVersion?g=com.blackducksoftware.integration&a=hub-detect&repos=bds-integrations-release')
+      DETECT_RELEASE_VERSION=$(curl $DETECT_CURL_OPTS 'https://test-repo.blackducksoftware.com/artifactory/api/search/latestVersion?g=com.blackducksoftware.integration&a=hub-detect&repos=bds-integrations-release')
       DETECT_SOURCE="https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/hub-detect/${DETECT_RELEASE_VERSION}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
       DETECT_DESTINATION="${DETECT_JAR_PATH}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
     else


### PR DESCRIPTION
Adding the the curl options to this call will allow for additional curl parameters to be set, including setting the proxy information. This pattern matches the rest of the curl calls in this file.