### PR TITLE
Phone home update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,7 @@ plugins {
     id 'org.springframework.boot' version '1.5.10.RELEASE'
     id 'maven-publish'
 }
-repositories {
-    mavenLocal()
-}
+
 version = '3.1.0-SNAPSHOT'
 
 apply plugin: 'com.blackducksoftware.integration.solution'
@@ -69,7 +67,7 @@ artifactory {
 }
 
 dependencies {
-    compile 'com.blackducksoftware.integration:hub-common:27.0.0-SNAPSHOT'
+    compile 'com.blackducksoftware.integration:hub-common:27.0.0'
     compile 'org.apache.commons:commons-text:1.2'
     compile 'org.springframework.boot:spring-boot-starter'
     compile 'org.apache.maven.shared:maven-invoker:3.0.0'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.groovy
@@ -55,13 +55,13 @@ import groovy.transform.TypeChecked
 class DetectConfiguration {
     private final Logger logger = LoggerFactory.getLogger(DetectConfiguration.class)
 
-    static final String DETECT_PROPERTY_PREFIX = 'detect.'
-    static final String DOCKER_PROPERTY_PREFIX = 'detect.docker.passthrough.'
-    static final String PHONE_HOME_PROPERTY_PREFIX = 'detect.phone.home.passthrough.'
-    static final String DOCKER_ENVIRONMENT_PREFIX = 'DETECT_DOCKER_PASSTHROUGH_'
-    static final String NUGET = 'nuget'
-    static final String GRADLE = 'gradle'
-    static final String DOCKER = 'docker'
+    public static final String DETECT_PROPERTY_PREFIX = 'detect.'
+    public static final String DOCKER_PROPERTY_PREFIX = 'detect.docker.passthrough.'
+    public static final String PHONE_HOME_PROPERTY_PREFIX = 'detect.phone.home.passthrough.'
+    public static final String DOCKER_ENVIRONMENT_PREFIX = 'DETECT_DOCKER_PASSTHROUGH_'
+    public static final String NUGET = 'nuget'
+    public static final String GRADLE = 'gradle'
+    public static final String DOCKER = 'docker'
 
     private static final String GROUP_HUB_CONFIGURATION = 'hub configuration'
     private static final String GROUP_GENERAL = 'general'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
@@ -23,18 +23,60 @@
  */
 package com.blackducksoftware.integration.hub.detect;
 
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.blackducksoftware.integration.hub.detect.model.BomToolType;
 import com.blackducksoftware.integration.hub.service.PhoneHomeService;
 import com.blackducksoftware.integration.hub.service.model.PhoneHomeResponse;
 import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody;
+import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBodyBuilder;
+import com.blackducksoftware.integration.phonehome.enums.ThirdPartyName;
 
 @Component
 public class DetectPhoneHomeManager {
+    @Autowired
+    private DetectInfo detectInfo;
+
+    @Autowired
+    private DetectConfiguration detectConfiguration;
+
+    private PhoneHomeService phoneHomeService;
     private PhoneHomeResponse phoneHomeResponse;
 
-    public void startPhoneHome(final PhoneHomeService phoneHomeDataService, final PhoneHomeRequestBody phoneHomeRequestBody) {
-        phoneHomeResponse = phoneHomeDataService.startPhoneHome(phoneHomeRequestBody);
+    public void init(final PhoneHomeService phoneHomeService) {
+        this.phoneHomeService = phoneHomeService;
+    }
+
+    public void startPhoneHome() {
+        // hub-detect will attempt to phone home twice - once upon startup and
+        // once upon completion of uploading all bdio files.
+        //
+        // We would prefer to always wait for all the bdio metadata, but
+        // sometimes after the bdio uploads, there is not enough time to
+        // complete a phone home before hub-detect exits (if the scanner is
+        // disabled, for example).
+        endPhoneHome();
+
+        final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = createBuilder();
+        final PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
+
+        phoneHomeResponse = phoneHomeService.startPhoneHome(phoneHomeRequestBody);
+    }
+
+    public void startPhoneHome(final Set<BomToolType> applicableBomToolTypes) {
+        endPhoneHome();
+
+        final String applicableBomToolsString = StringUtils.join(applicableBomToolTypes, ", ");
+
+        final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = createBuilder();
+        phoneHomeRequestBodyBuilder.addToMetaDataMap("bomToolTypes", applicableBomToolsString);
+        final PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
+
+        phoneHomeResponse = phoneHomeService.startPhoneHome(phoneHomeRequestBody);
     }
 
     public void endPhoneHome() {
@@ -45,6 +87,22 @@ public class DetectPhoneHomeManager {
 
     public PhoneHomeResponse getPhoneHomeResponse() {
         return phoneHomeResponse;
+    }
+
+    private PhoneHomeRequestBodyBuilder createBuilder() {
+        final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = phoneHomeService.createInitialPhoneHomeRequestBodyBuilder(ThirdPartyName.DETECT, detectInfo.getDetectVersion(), detectInfo.getDetectVersion());
+        detectConfiguration.getAdditionalPhoneHomePropertyNames().stream().forEach(propertyName -> {
+            final String actualKey = getKeyWithoutPrefix(propertyName, DetectConfiguration.PHONE_HOME_PROPERTY_PREFIX);
+            final String value = detectConfiguration.getDetectProperty(propertyName);
+            phoneHomeRequestBodyBuilder.addToMetaDataMap(actualKey, value);
+        });
+
+        return phoneHomeRequestBodyBuilder;
+    }
+
+    private String getKeyWithoutPrefix(final String key, final String prefix) {
+        final int prefixIndex = key.indexOf(prefix) + prefix.length();
+        return key.substring(prefixIndex);
     }
 
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
@@ -53,12 +53,11 @@ public class DetectPhoneHomeManager {
 
     public void startPhoneHome() {
         // hub-detect will attempt to phone home twice - once upon startup and
-        // once upon completion of uploading all bdio files.
+        // once upon getting all the bom tool metadata.
         //
-        // We would prefer to always wait for all the bdio metadata, but
-        // sometimes after the bdio uploads, there is not enough time to
-        // complete a phone home before hub-detect exits (if the scanner is
-        // disabled, for example).
+        // We would prefer to always wait for all the bom tool metadata, but
+        // sometimes there is not enough time to complete a phone home before
+        // hub-detect exits (if the scanner is disabled, for example).
         endPhoneHome();
 
         final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = createBuilder();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectPhoneHomeManager.java
@@ -58,21 +58,23 @@ public class DetectPhoneHomeManager {
         // We would prefer to always wait for all the bom tool metadata, but
         // sometimes there is not enough time to complete a phone home before
         // hub-detect exits (if the scanner is disabled, for example).
-        endPhoneHome();
-
-        final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = createBuilder();
-        final PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
-
-        phoneHomeResponse = phoneHomeService.startPhoneHome(phoneHomeRequestBody);
+        performPhoneHome(null);
     }
 
     public void startPhoneHome(final Set<BomToolType> applicableBomToolTypes) {
+        performPhoneHome(applicableBomToolTypes);
+    }
+
+    private void performPhoneHome(final Set<BomToolType> applicableBomToolTypes) {
         endPhoneHome();
 
-        final String applicableBomToolsString = StringUtils.join(applicableBomToolTypes, ", ");
-
         final PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = createBuilder();
-        phoneHomeRequestBodyBuilder.addToMetaDataMap("bomToolTypes", applicableBomToolsString);
+
+        if (applicableBomToolTypes != null) {
+            final String applicableBomToolsString = StringUtils.join(applicableBomToolTypes, ", ");
+            phoneHomeRequestBodyBuilder.addToMetaDataMap("bomToolTypes", applicableBomToolsString);
+        }
+
         final PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
 
         phoneHomeResponse = phoneHomeService.startPhoneHome(phoneHomeRequestBody);

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
@@ -160,13 +160,13 @@ class DetectProjectManager implements SummaryResultReporter, ExitCodeReporter {
                 CodeLocationName codeLocationName = codeLocationNameService.createBomToolName(it.sourcePath, projectName, projectVersionName, it.bomToolType, prefix, suffix)
                 String codeLocationNameString = codeLocationNameService.generateBomToolCurrent(codeLocationName)
                 if (!codeLocationNames.add(codeLocationNameString)) {
-                    throw new DetectUserFriendlyException("Found duplicate Code Locations with the name : ${codeLocationNameString}", ExitCodeType.FAILURE_GENERAL_ERROR)
+                    throw new DetectUserFriendlyException("Found duplicate Code Locations with the name: ${codeLocationNameString}", ExitCodeType.FAILURE_GENERAL_ERROR)
                 }
                 final SimpleBdioDocument simpleBdioDocument = createSimpleBdioDocument(codeLocationNameString, detectProject, it)
                 String finalSourcePathPiece = detectFileManager.extractFinalPieceFromPath(it.sourcePath);
                 final String filename = generateShortenedFilename(it.bomToolType, finalSourcePathPiece, it.getBomToolProjectExternalId());
                 if (!bdioFileNames.add(filename)) {
-                    throw new DetectUserFriendlyException("Found duplicate Bdio files with the name : ${filename}", ExitCodeType.FAILURE_GENERAL_ERROR)
+                    throw new DetectUserFriendlyException("Found duplicate Bdio files with the name: ${filename}", ExitCodeType.FAILURE_GENERAL_ERROR)
                 }
                 final File outputFile = new File(detectConfiguration.bdioOutputDirectoryPath, filename)
                 if (outputFile.exists()) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -30,8 +30,6 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.configuration.HubServerConfig
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
-import com.blackducksoftware.integration.hub.detect.DetectPhoneHomeManager
-import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
 import com.blackducksoftware.integration.hub.service.CodeLocationService
 
@@ -45,9 +43,6 @@ class BdioUploader {
     @Autowired
     DetectConfiguration detectConfiguration
 
-    @Autowired
-    DetectPhoneHomeManager detectPhoneHomeManager
-
     void uploadBdioFiles(HubServerConfig hubServerConfig, CodeLocationService codeLocationService, DetectProject detectProject, List<File> createdBdioFiles) {
         createdBdioFiles.each { file ->
             logger.info("uploading ${file.name} to ${detectConfiguration.getHubUrl()}")
@@ -56,8 +51,5 @@ class BdioUploader {
                 file.delete()
             }
         }
-
-        Set<BomToolType> applicableBomTools = detectProject.getApplicableBomTools();
-        detectPhoneHomeManager.startPhoneHome(applicableBomTools);
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/BdioUploader.groovy
@@ -23,7 +23,6 @@
  */
 package com.blackducksoftware.integration.hub.detect.hub
 
-import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,15 +30,10 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.configuration.HubServerConfig
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
-import com.blackducksoftware.integration.hub.detect.DetectInfo
 import com.blackducksoftware.integration.hub.detect.DetectPhoneHomeManager
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
 import com.blackducksoftware.integration.hub.service.CodeLocationService
-import com.blackducksoftware.integration.hub.service.PhoneHomeService
-import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBody
-import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBodyBuilder
-import com.blackducksoftware.integration.phonehome.enums.ThirdPartyName
 
 import groovy.transform.TypeChecked
 
@@ -49,15 +43,12 @@ class BdioUploader {
     private final Logger logger = LoggerFactory.getLogger(BdioUploader.class)
 
     @Autowired
-    DetectInfo detectInfo
-
-    @Autowired
     DetectConfiguration detectConfiguration
 
     @Autowired
     DetectPhoneHomeManager detectPhoneHomeManager
 
-    void uploadBdioFiles(HubServerConfig hubServerConfig, CodeLocationService codeLocationService, PhoneHomeService phoneHomeService, DetectProject detectProject, List<File> createdBdioFiles) {
+    void uploadBdioFiles(HubServerConfig hubServerConfig, CodeLocationService codeLocationService, DetectProject detectProject, List<File> createdBdioFiles) {
         createdBdioFiles.each { file ->
             logger.info("uploading ${file.name} to ${detectConfiguration.getHubUrl()}")
             codeLocationService.importBomFile(file)
@@ -66,26 +57,7 @@ class BdioUploader {
             }
         }
 
-        String hubDetectVersion = detectInfo.detectVersion
         Set<BomToolType> applicableBomTools = detectProject.getApplicableBomTools();
-        String applicableBomToolsString = StringUtils.join(applicableBomTools, ", ");
-
-        PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder = phoneHomeService.createInitialPhoneHomeRequestBodyBuilder(ThirdPartyName.DETECT, hubDetectVersion, hubDetectVersion);
-        phoneHomeRequestBodyBuilder.addToMetaDataMap('bomToolTypes', applicableBomToolsString);
-        addAdditionalPhoneHomeMetaData(phoneHomeRequestBodyBuilder);
-
-        PhoneHomeRequestBody phoneHomeRequestBody = phoneHomeRequestBodyBuilder.build();
-        detectPhoneHomeManager.startPhoneHome(phoneHomeService, phoneHomeRequestBody);
-    }
-
-    public void addAdditionalPhoneHomeMetaData(PhoneHomeRequestBodyBuilder phoneHomeRequestBodyBuilder) {
-        detectConfiguration.additionalPhoneHomePropertyNames.each { propertyName ->
-            String actualKey = getKeyWithoutPrefix(propertyName, DetectConfiguration.PHONE_HOME_PROPERTY_PREFIX)
-            String value = detectConfiguration.getDetectProperty(propertyName);
-            phoneHomeRequestBodyBuilder.addToMetaDataMap(actualKey, value);
-        }
-    }
-    private String getKeyWithoutPrefix(String key, String prefix) {
-        return key[prefix.length()..-1]
+        detectPhoneHomeManager.startPhoneHome(applicableBomTools);
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubManager.groovy
@@ -44,7 +44,6 @@ import com.blackducksoftware.integration.hub.exception.DoesNotExistException
 import com.blackducksoftware.integration.hub.rest.exception.IntegrationRestException
 import com.blackducksoftware.integration.hub.service.CodeLocationService
 import com.blackducksoftware.integration.hub.service.HubService
-import com.blackducksoftware.integration.hub.service.PhoneHomeService
 import com.blackducksoftware.integration.hub.service.ProjectService
 import com.blackducksoftware.integration.hub.service.ReportService
 import com.blackducksoftware.integration.hub.service.ScanStatusService
@@ -83,8 +82,7 @@ class HubManager implements ExitCodeReporter {
         if (createdBdioFiles) {
             HubServerConfig hubServerConfig = hubServiceWrapper.hubServerConfig
             CodeLocationService codeLocationService = hubServiceWrapper.createCodeLocationService()
-            PhoneHomeService phoneHomeService = hubServiceWrapper.createPhoneHomeService()
-            bdioUploader.uploadBdioFiles(hubServerConfig, codeLocationService, phoneHomeService, detectProject, createdBdioFiles)
+            bdioUploader.uploadBdioFiles(hubServerConfig, codeLocationService, detectProject, createdBdioFiles)
         } else {
             logger.debug('Did not create any bdio files.')
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.groovy
@@ -35,6 +35,7 @@ import com.blackducksoftware.integration.hub.api.generated.response.CurrentVersi
 import com.blackducksoftware.integration.hub.configuration.HubServerConfig
 import com.blackducksoftware.integration.hub.configuration.HubServerConfigBuilder
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration
+import com.blackducksoftware.integration.hub.detect.DetectPhoneHomeManager
 import com.blackducksoftware.integration.hub.detect.exception.DetectUserFriendlyException
 import com.blackducksoftware.integration.hub.detect.exitcode.ExitCodeType
 import com.blackducksoftware.integration.hub.rest.RestConnection
@@ -60,6 +61,9 @@ class HubServiceWrapper {
     @Autowired
     DetectConfiguration detectConfiguration
 
+    @Autowired
+    DetectPhoneHomeManager detectPhoneHomeManager
+
     Slf4jIntLogger slf4jIntLogger
     HubServerConfig hubServerConfig
     HubServicesFactory hubServicesFactory
@@ -75,6 +79,8 @@ class HubServiceWrapper {
         HubService hubService = createHubService()
         CurrentVersionView currentVersion = hubService.getResponse(ApiDiscovery.CURRENT_VERSION_LINK_RESPONSE)
         logger.info(String.format("Successfully connected to Hub (version %s)!", currentVersion.version))
+        detectPhoneHomeManager.init(createPhoneHomeService());
+        detectPhoneHomeManager.startPhoneHome();
     }
 
     public boolean testHubConnection() {
@@ -119,7 +125,6 @@ class HubServiceWrapper {
     PhoneHomeService createPhoneHomeService() {
         hubServicesFactory.createPhoneHomeService()
     }
-
 
     CodeLocationService createCodeLocationService() {
         hubServicesFactory.createCodeLocationService()

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -76,10 +76,24 @@ class HubSignatureScanner implements SummaryResultReporter, ExitCodeReporter {
     private Map<String, Result> scanSummaryResults = new HashMap<>();
 
     public void registerPathToScan(File file, String... fileNamesToExclude) {
+        registerPathToScan(file, fileNamesToExclude, false);
+    }
+
+    /**
+     * When the scanner is NOT enabled, no paths will be registered to scan.
+     *
+     * If the scanner is enabled and there is at least one explicit path set, ONLY the explicit path(s) will be scanned.
+     *
+     * If the scanner is enabled, no explicit paths are set, and snippet mode is enabled, ONLY the source path will be scanned.
+     *
+     * In all other cases, the bom tools will, when they can, identify good candidates for registering scan targets.
+     */
+    public void registerPathToScan(File file, String... fileNamesToExclude, boolean forceRegistering) {
         boolean scannerEnabled = !detectConfiguration.hubSignatureScannerDisabled;
         boolean customPathOverride = detectConfiguration.hubSignatureScannerPaths.size() > 0;
+        boolean snippetModeEnabled = detectConfiguration.hubSignatureScannerSnippetMode;
 
-        if (scannerEnabled && !customPathOverride) {
+        if (scannerEnabled && (!customPathOverride && !snippetModeEnabled || forceRegistering)) {
             String matchingExcludedPath = detectConfiguration.hubSignatureScannerPathsToExclude.find {
                 file.canonicalPath.startsWith(it)
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/BomToolType.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/BomToolType.java
@@ -44,4 +44,5 @@ public enum BomToolType {
     RUBYGEMS,
     SBT,
     YARN;
+
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/DetectProject.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/model/DetectProject.groovy
@@ -72,14 +72,6 @@ class DetectProject {
         detectCodeLocations.add(detectCodeLocation)
     }
 
-    public Set<BomToolType> getApplicableBomTools() {
-        Set<BomToolType> applicableBomTools = new HashSet<>();
-        for (DetectCodeLocation detectCodeLocation : detectCodeLocations) {
-            applicableBomTools.add(detectCodeLocation.getBomToolType());
-        }
-        return applicableBomTools;
-    }
-
     public List<DetectCodeLocation> getDetectCodeLocations() {
         detectCodeLocations
     }


### PR DESCRIPTION
Instead of introducing an explicit wait so that the phone home with all the meta data can complete, we now will simply phone home twice - once at the beginning of detect's run and a second time once we have all the data.

This is my attempt to remain true to the principle of not harming the customer with phone-home. Do these few seconds really matter? We can discuss.