### PR TITLE
creating the ScanPathSource

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectProjectManager.groovy
@@ -46,6 +46,7 @@ import com.blackducksoftware.integration.hub.detect.exception.DetectUserFriendly
 import com.blackducksoftware.integration.hub.detect.exitcode.ExitCodeReporter
 import com.blackducksoftware.integration.hub.detect.exitcode.ExitCodeType
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
@@ -139,7 +140,10 @@ class DetectProjectManager implements SummaryResultReporter, ExitCodeReporter {
 
         if (!foundAnyBomTools) {
             logger.info("No package managers were detected - will register ${detectConfiguration.sourcePath} for signature scanning of ${detectProject.projectName}/${detectProject.projectVersionName}")
-            hubSignatureScanner.registerPathToScan(detectConfiguration.sourceDirectory)
+            hubSignatureScanner.registerPathToScan(ScanPathSource.DETECT_SOURCE, detectConfiguration.sourceDirectory)
+        } else if (detectConfiguration.hubSignatureScannerSnippetMode) {
+            logger.info("Snippet mode is enabled - will register ${detectConfiguration.sourcePath} for signature scanning of ${detectProject.projectName}/${detectProject.projectVersionName}")
+            hubSignatureScanner.registerPathToScan(ScanPathSource.SNIPPET_SOURCE, detectConfiguration.sourceDirectory)
         }
 
         detectProject

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/DockerBomTool.groovy
@@ -39,6 +39,7 @@ import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalIdFac
 import com.blackducksoftware.integration.hub.detect.bomtool.docker.DockerInspectorManager
 import com.blackducksoftware.integration.hub.detect.bomtool.docker.DockerProperties
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
@@ -147,11 +148,11 @@ class DockerBomTool extends BomTool {
         executableRunner.execute(dockerExecutable)
 
         if (usingTarFile) {
-            hubSignatureScanner.registerPathToScan(new File(detectConfiguration.dockerTar))
+            hubSignatureScanner.registerPathToScan(ScanPathSource.DOCKER_SOURCE, new File(detectConfiguration.dockerTar))
         } else {
             File producedTarFile = detectFileManager.findFile(dockerBomToolDirectory, tarFilenamePattern)
             if (producedTarFile) {
-                hubSignatureScanner.registerPathToScan(producedTarFile)
+                hubSignatureScanner.registerPathToScan(ScanPathSource.DOCKER_SOURCE, producedTarFile)
             } else {
                 logMissingFile(dockerBomToolDirectory, tarFilenamePattern)
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/GradleBomTool.groovy
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component
 import com.blackducksoftware.integration.hub.detect.bomtool.gradle.GradleInspectorManager
 import com.blackducksoftware.integration.hub.detect.bomtool.gradle.GradleReportParser
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.model.DetectProject
@@ -83,7 +84,7 @@ class GradleBomTool extends BomTool {
         File[] additionalTargets = detectFileManager.findFilesToDepth(detectConfiguration.sourceDirectory, 'build', detectConfiguration.searchDepth)
         if (additionalTargets) {
             additionalTargets.each { File file ->
-                hubSignatureScanner.registerPathToScan(file)
+                hubSignatureScanner.registerPathToScan(ScanPathSource.GRADLE_SOURCE, file)
             }
         }
         codeLocations

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/MavenBomTool.groovy
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component
 
 import com.blackducksoftware.integration.hub.detect.bomtool.maven.MavenCodeLocationPackager
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
@@ -95,7 +96,9 @@ class MavenBomTool extends BomTool {
 
         File[] additionalTargets = detectFileManager.findFilesToDepth(detectConfiguration.sourceDirectory, 'target', detectConfiguration.searchDepth)
         if (additionalTargets) {
-            additionalTargets.each { File target -> hubSignatureScanner.registerPathToScan(target) }
+            additionalTargets.each { File target ->
+                hubSignatureScanner.registerPathToScan(ScanPathSource.MAVEN_SOURCE, target)
+            }
         }
 
         codeLocations

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/NpmBomTool.groovy
@@ -32,6 +32,7 @@ import com.blackducksoftware.integration.hub.detect.DetectConfiguration
 import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmCliDependencyFinder
 import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmLockfilePackager
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
@@ -133,7 +134,7 @@ class NpmBomTool extends BomTool {
         }
 
         if (!codeLocations.empty) {
-            hubSignatureScanner.registerPathToScan(sourceDirectory, NODE_MODULES)
+            hubSignatureScanner.registerPathToScan(ScanPathSource.NPM_SOURCE, sourceDirectory, NODE_MODULES)
         }
 
         codeLocations

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/SbtBomTool.groovy
@@ -34,6 +34,7 @@ import com.blackducksoftware.integration.hub.detect.bomtool.sbt.SbtPackager
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtDependencyModule
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.models.SbtProject
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 
@@ -169,7 +170,7 @@ class SbtBomTool extends BomTool {
         if (additionalTargets) {
             additionalTargets.each { file ->
                 if (!isInProject(file, sourcePath) && isNotChildOfScanned(file, scanned)) {
-                    hubSignatureScanner.registerPathToScan(file)
+                    hubSignatureScanner.registerPathToScan(ScanPathSource.SBT_SOURCE, file)
                     scanned.add(file)
                 }
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetInspectorPackager.groovy
@@ -37,6 +37,7 @@ import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetCon
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetContainerType
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.model.NugetInspection
 import com.blackducksoftware.integration.hub.detect.hub.HubSignatureScanner
+import com.blackducksoftware.integration.hub.detect.hub.ScanPathSource
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.nameversion.NameVersionNodeTransformer
@@ -87,7 +88,7 @@ class NugetInspectorPackager {
 
     private void registerScanPaths(NugetContainer nugetContainer) {
         nugetContainer.outputPaths?.each {
-            hubSignatureScanner?.registerPathToScan(new File(it))
+            hubSignatureScanner?.registerPathToScan(ScanPathSource.NUGET_SOURCE, new File(it))
         }
         nugetContainer.children?.each { registerScanPaths(it) }
     }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -184,7 +184,6 @@ class HubSignatureScanner implements SummaryResultReporter, ExitCodeReporter {
         String matchingExcludedPath = detectConfiguration.hubSignatureScannerPathsToExclude.find {
             file.canonicalPath.startsWith(it)
         }
-
         if (matchingExcludedPath) {
             logger.info("Not scanning path ${file.canonicalPath}, it is excluded.")
             return false;

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.groovy
@@ -75,58 +75,29 @@ class HubSignatureScanner implements SummaryResultReporter, ExitCodeReporter {
     private Set<String> registeredPathsToExclude = []
     private Map<String, Result> scanSummaryResults = new HashMap<>();
 
-    public void registerPathToScan(File file, String... fileNamesToExclude) {
-        registerPathToScan(file, fileNamesToExclude, false);
-    }
+    public void registerPathToScan(ScanPathSource scanPathSource, File file, String... fileNamesToExclude) {
+        boolean shouldRegisterPath = shouldRegisterPathForScanning(file, scanPathSource);
 
-    /**
-     * When the scanner is NOT enabled, no paths will be registered to scan.
-     *
-     * If the scanner is enabled and there is at least one explicit path set, ONLY the explicit path(s) will be scanned.
-     *
-     * If the scanner is enabled, no explicit paths are set, and snippet mode is enabled, ONLY the source path will be scanned.
-     *
-     * In all other cases, the bom tools will, when they can, identify good candidates for registering scan targets.
-     */
-    public void registerPathToScan(File file, String... fileNamesToExclude, boolean forceRegistering) {
-        boolean scannerEnabled = !detectConfiguration.hubSignatureScannerDisabled;
-        boolean customPathOverride = detectConfiguration.hubSignatureScannerPaths.size() > 0;
-        boolean snippetModeEnabled = detectConfiguration.hubSignatureScannerSnippetMode;
-
-        if (scannerEnabled && (!customPathOverride && !snippetModeEnabled || forceRegistering)) {
-            String matchingExcludedPath = detectConfiguration.hubSignatureScannerPathsToExclude.find {
-                file.canonicalPath.startsWith(it)
-            }
-
-            if (matchingExcludedPath) {
-                logger.info("Not registering excluded path ${file.canonicalPath} to scan")
-            } else if (file.exists() && (file.isFile() || file.isDirectory())) {
-                logger.info("Registering path ${file.canonicalPath} to scan")
-                scanSummaryResults.put(file.getCanonicalPath(), Result.FAILURE);
-                registeredPaths.add(file.canonicalPath)
-                if (fileNamesToExclude) {
-                    for (String fileNameToExclude : fileNamesToExclude) {
-                        File fileToExclude = detectFileManager.findFile(file, fileNameToExclude)
-                        if (fileToExclude) {
-                            String pattern = fileToExclude.getCanonicalPath().replace(file.canonicalPath, '')
-                            if (pattern.contains('\\\\')) {
-                                pattern = pattern.replace('\\\\', '/')
-                            }
-                            if (pattern.contains('\\')) {
-                                pattern = pattern.replace('\\', '/')
-                            }
-                            pattern = pattern + '/'
-                            registeredPathsToExclude.add(pattern)
+        if (shouldRegisterPath) {
+            logger.info("Registering path ${file.canonicalPath} to scan")
+            scanSummaryResults.put(file.getCanonicalPath(), Result.FAILURE);
+            registeredPaths.add(file.canonicalPath)
+            if (fileNamesToExclude) {
+                for (String fileNameToExclude : fileNamesToExclude) {
+                    File fileToExclude = detectFileManager.findFile(file, fileNameToExclude)
+                    if (fileToExclude) {
+                        String pattern = fileToExclude.getCanonicalPath().replace(file.canonicalPath, '')
+                        if (pattern.contains('\\\\')) {
+                            pattern = pattern.replace('\\\\', '/')
                         }
+                        if (pattern.contains('\\')) {
+                            pattern = pattern.replace('\\', '/')
+                        }
+                        pattern = pattern + '/'
+                        registeredPathsToExclude.add(pattern)
                     }
                 }
-            } else {
-                logger.warn("Tried to register a scan for ${file.canonicalPath} but it doesn't appear to exist or it isn't a file or directory.")
             }
-        } else if (!scannerEnabled) {
-            logger.info("Not registering path ${file.canonicalPath}, scan is disabled");
-        } else if (customPathOverride) {
-            logger.info("Not scanning path ${file.canonicalPath}, scan paths provided");
         }
     }
 
@@ -198,6 +169,42 @@ class HubSignatureScanner implements SummaryResultReporter, ExitCodeReporter {
         return ExitCodeType.SUCCESS;
     }
 
+    private boolean shouldRegisterPathForScanning(File file, ScanPathSource scanPathSource) {
+        if (detectConfiguration.hubSignatureScannerDisabled) {
+            logger.info("Not scanning path ${file.canonicalPath}, the signature scanner is disabled.");
+            return false;
+        }
+
+        boolean customPathOverride = detectConfiguration.hubSignatureScannerPaths.size() > 0;
+        if (customPathOverride) {
+            logger.info("Not scanning path ${file.canonicalPath}, explicit scan paths were provided.");
+            return false;
+        }
+
+        String matchingExcludedPath = detectConfiguration.hubSignatureScannerPathsToExclude.find {
+            file.canonicalPath.startsWith(it)
+        }
+
+        if (matchingExcludedPath) {
+            logger.info("Not scanning path ${file.canonicalPath}, it is excluded.")
+            return false;
+        }
+
+        if (!file.exists() || (!file.isFile() && !file.isDirectory())) {
+            logger.warn("Not scanning path ${file.canonicalPath}, it doesn't appear to exist or it isn't a file or directory.")
+            return false;
+        }
+
+        boolean snippetModeEnabled = detectConfiguration.hubSignatureScannerSnippetMode;
+        String sourcePath = detectConfiguration.sourcePath
+        if (snippetModeEnabled && !(scanPathSource.equals(ScanPathSource.DOCKER_SOURCE) || scanPathSource.equals(ScanPathSource.SNIPPET_SOURCE))) {
+            logger.info("Not scanning path ${file.canonicalPath}, snippet mode is enabled and ${scanPathSource.source} paths should be scanned when ${sourcePath} is scanned.")
+            return false;
+        }
+
+        return true;
+    }
+
     private void scanPathOffline(String canonicalPath, DetectProject detectProject) {
         try {
             HubScanConfigBuilder hubScanConfigBuilder = createScanConfigBuilder(detectProject, canonicalPath)
@@ -211,7 +218,7 @@ class HubSignatureScanner implements SummaryResultReporter, ExitCodeReporter {
 
             HubScanConfig hubScanConfig = hubScanConfigBuilder.build()
             boolean pathWasScanned = offlineScanner.offlineScan(detectProject, hubScanConfig, detectConfiguration.hubSignatureScannerOfflineLocalPath)
-            if(pathWasScanned) {
+            if (pathWasScanned) {
                 scanSummaryResults.put(canonicalPath, Result.SUCCESS);
                 logger.info("${canonicalPath} was successfully scanned by the BlackDuck CLI.")
             }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/ScanPathSource.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/ScanPathSource.java
@@ -1,0 +1,54 @@
+/**
+ * hub-detect
+ *
+ * Copyright (C) 2018 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.detect.hub;
+
+import com.blackducksoftware.integration.hub.detect.model.BomToolType;
+import com.blackducksoftware.integration.util.Stringable;
+
+public class ScanPathSource extends Stringable {
+    public static final ScanPathSource DOCKER_SOURCE = new ScanPathSource(BomToolType.DOCKER.toString());
+    public static final ScanPathSource NUGET_SOURCE = new ScanPathSource(BomToolType.NUGET.toString());
+    public static final ScanPathSource GRADLE_SOURCE = new ScanPathSource(BomToolType.GRADLE.toString());
+    public static final ScanPathSource MAVEN_SOURCE = new ScanPathSource(BomToolType.MAVEN.toString());
+    public static final ScanPathSource NPM_SOURCE = new ScanPathSource(BomToolType.NPM.toString());
+    public static final ScanPathSource SBT_SOURCE = new ScanPathSource(BomToolType.SBT.toString());
+    public static final ScanPathSource DETECT_SOURCE = new ScanPathSource("DETECT");
+    public static final ScanPathSource SNIPPET_SOURCE = new ScanPathSource("SNIPPET");
+
+    private final String source;
+
+    public ScanPathSource(final String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public String toString() {
+        return source;
+    }
+
+}


### PR DESCRIPTION
Now, each time a path is registered, the source of the register request is required (ScanPathSource). This can keep the logic of when to allow certain sources to register scan paths localized to the signature scanner code.

The big ideas are in HubSignatureScanner.