### PR TITLE
Add Hub Detect Property to Bypass Local Proxy for On Premise Hub. 

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
@@ -390,7 +390,7 @@ public class DetectConfiguration {
     @Value("${blackduck.hub.password:}")
     private String hubPassword;
     
-    @ValueDescription(description = "If true, proxy connectiont is bypassed for an on premise Hub installation.", defaultValue = "false", group = DetectConfiguration.GROUP_HUB_CONFIGURATION)
+    @ValueDescription(description = "If true, proxy connection is bypassed for an on premise Hub installation.", defaultValue = "false", group = DetectConfiguration.GROUP_HUB_CONFIGURATION)
     @Value("${blackduck.hub.onpremise:}")
     private Boolean hubOnPremise;
 
@@ -819,7 +819,7 @@ public class DetectConfiguration {
     }
 
     public Boolean getHubOnPremise()  {
-        return hubOnPremise;
+        return BooleanUtils.toBoolean(hubOnPremise);
     }
     public String getHubApiToken() {
         return hubApiToken;

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
@@ -389,6 +389,10 @@ public class DetectConfiguration {
     @ValueDescription(description = "Hub password", group = DetectConfiguration.GROUP_HUB_CONFIGURATION)
     @Value("${blackduck.hub.password:}")
     private String hubPassword;
+    
+    @ValueDescription(description = "If true, proxy connectiont is bypassed for an on premise Hub installation.", defaultValue = "false", group = DetectConfiguration.GROUP_HUB_CONFIGURATION)
+    @Value("${blackduck.hub.onpremise:}")
+    private Boolean hubOnPremise;
 
     @ValueDescription(description = "Hub API Token", group = DetectConfiguration.GROUP_HUB_CONFIGURATION)
     @Value("${blackduck.hub.api.token:}")
@@ -814,6 +818,9 @@ public class DetectConfiguration {
         return hubPassword;
     }
 
+    public Boolean getHubOnPremise()  {
+        return hubOnPremise;
+    }
     public String getHubApiToken() {
         return hubApiToken;
     }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.java
@@ -145,13 +145,24 @@ public class HubServiceWrapper {
         hubServerConfigBuilder.setUsername(detectConfiguration.getHubUsername());
         hubServerConfigBuilder.setPassword(detectConfiguration.getHubPassword());
         hubServerConfigBuilder.setApiToken(detectConfiguration.getHubApiToken());
+        if(detectConfiguration.getHubOnPremise())
+        {
+            logger.debug("Hub deployed on premise, bypassing proxy settings");
+            hubServerConfigBuilder.setProxyHost(null);
+            hubServerConfigBuilder.setProxyPort(null);
+            hubServerConfigBuilder.setProxyUsername(null);
+            hubServerConfigBuilder.setProxyPassword(null);
+            hubServerConfigBuilder.setProxyNtlmDomain(null);
+            hubServerConfigBuilder.setProxyNtlmWorkstation(null);
+        } else {
+            hubServerConfigBuilder.setProxyHost(detectConfiguration.getHubProxyHost());
+            hubServerConfigBuilder.setProxyPort(detectConfiguration.getHubProxyPort());
+            hubServerConfigBuilder.setProxyUsername(detectConfiguration.getHubProxyUsername());
+            hubServerConfigBuilder.setProxyPassword(detectConfiguration.getHubProxyPassword());
+            hubServerConfigBuilder.setProxyNtlmDomain(detectConfiguration.getHubProxyNtlmDomain());
+            hubServerConfigBuilder.setProxyNtlmWorkstation(detectConfiguration.getHubProxyNtlmWorkstation());
+        }
 
-        hubServerConfigBuilder.setProxyHost(detectConfiguration.getHubProxyHost());
-        hubServerConfigBuilder.setProxyPort(detectConfiguration.getHubProxyPort());
-        hubServerConfigBuilder.setProxyUsername(detectConfiguration.getHubProxyUsername());
-        hubServerConfigBuilder.setProxyPassword(detectConfiguration.getHubProxyPassword());
-        hubServerConfigBuilder.setProxyNtlmDomain(detectConfiguration.getHubProxyNtlmDomain());
-        hubServerConfigBuilder.setProxyNtlmWorkstation(detectConfiguration.getHubProxyNtlmWorkstation());
         hubServerConfigBuilder.setAlwaysTrustServerCertificate(detectConfiguration.getHubTrustCertificate());
         hubServerConfigBuilder.setLogger(slf4jIntLogger);
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubServiceWrapper.java
@@ -145,9 +145,8 @@ public class HubServiceWrapper {
         hubServerConfigBuilder.setUsername(detectConfiguration.getHubUsername());
         hubServerConfigBuilder.setPassword(detectConfiguration.getHubPassword());
         hubServerConfigBuilder.setApiToken(detectConfiguration.getHubApiToken());
-        if(detectConfiguration.getHubOnPremise())
-        {
-            logger.debug("Hub deployed on premise, bypassing proxy settings");
+        if(detectConfiguration.getHubOnPremise()) {
+            logger.debug("Hub deployed on premise, bypassing proxy settings.");
             hubServerConfigBuilder.setProxyHost(null);
             hubServerConfigBuilder.setProxyPort(null);
             hubServerConfigBuilder.setProxyUsername(null);


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

*  

**If nothing above, what is your reason for this pull request:**

* I have an on premise installation of Black Duck hub. External access is only available via a proxy. I need to use the proxy to pull down the latest tools but, I cannot reach the on premise installation of the Hub through the proxy. The hub detect powershell scripts set the proxy globally which does not give you the granular option of when and where the proxy should be used. This additional Hub Detect property would allow us to bypass the proxy with an on premise installation of BlackDuck Hub. 

**Changes proposed in this pull request:**

* Add a Hub Detect Property "--blackduck.hub.onpremise" 
* Property default is set to false.
* If it is true set the proxy host, port, username, password, NTLM Domain, and NTLM Workstation to null. 