### PR TITLE
Nuget will combine 'solution project' code locations with same source path 

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetBomTool.groovy
@@ -191,7 +191,7 @@ class NugetBomTool extends BomTool {
                 logger.info("The code location's dependencies will be combined, in the future they will exist seperately for each solution.")
                 DetectCodeLocation destination = codeLocationsBySource.get(codeLocation.getSourcePath());
                 combiner.addGraphAsChildrenToRoot((MutableDependencyGraph) destination.getDependencyGraph(), codeLocation.getDependencyGraph());
-            }else {
+            } else {
                 codeLocationsBySource.put(codeLocation.getSourcePath(), codeLocation);
             }
         }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetBomTool.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/nuget/NugetBomTool.groovy
@@ -23,17 +23,16 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.nuget
 
-import com.blackducksoftware.integration.hub.detect.bomtool.BomTool
-import com.blackducksoftware.integration.hub.detect.codelocation.CodeLocationName
-
 import org.apache.commons.io.FileUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
 import com.blackducksoftware.integration.hub.bdio.graph.DependencyGraphCombiner
 import com.blackducksoftware.integration.hub.bdio.graph.MutableDependencyGraph
 import com.blackducksoftware.integration.hub.detect.DetectInfo
+import com.blackducksoftware.integration.hub.detect.bomtool.BomTool
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation
 import com.blackducksoftware.integration.hub.detect.type.ExecutableType
@@ -181,7 +180,7 @@ class NugetBomTool extends BomTool {
             logger.warn('Unable to extract any dependencies from nuget')
             return []
         }
-        
+
         Map<String, List<DetectCodeLocation>> codeLocationSourcePathMap = new HashMap<>();
         codeLocations.forEach { DetectCodeLocation codeLocation ->
             String sourcePath = codeLocation.getSourcePath();
@@ -190,7 +189,7 @@ class NugetBomTool extends BomTool {
             }
             codeLocationSourcePathMap.get(sourcePath).add(codeLocation);
         }
-        
+
         List<DetectCodeLocation> mergedCodeLocations = new ArrayList<>();
         DependencyGraphCombiner combiner = new DependencyGraphCombiner();
         for (def codeLocationList in codeLocationSourcePathMap.values()) {
@@ -200,10 +199,11 @@ class NugetBomTool extends BomTool {
                 logger.info("This most likely means the same project exists in multiple solutions.")
                 logger.info("The code location's dependencies will be combined, in the future they will exist seperately for each solution.")
                 codeLocationList.stream()
-                    .skip(1)
-                    .forEach{ 
-                        combiner.addGraphAsChildrenToRoot((MutableDependencyGraph) merger.getDependencyGraph(), it.getDependencyGraph()) 
-                    };
+                        .skip(1)
+                        .forEach{
+                            combiner.addGraphAsChildrenToRoot((MutableDependencyGraph) merger.getDependencyGraph(), it.getDependencyGraph())
+                        };
+                mergedCodeLocations.add(merger);
             }else if (codeLocationList.size() == 1) {
                 mergedCodeLocations.add(codeLocationList.first());
             }


### PR DESCRIPTION
This solves the issue of a single project being included in multiple solutions. For example, if I had one project Projects/ProjectA.csproj and it is referenced in SolutionA.sln and SolutionB.sln this will work.

It does not solve the problem of duplicate project names across all solutions. For example,  if I had two projects Projects/Web/ProjectA.csproj and Projects/Mobile/ProjectA.csproj and they are both referenced even in one solution SolutionA, this will still produce duplicate code location names.