### PR TITLE
Changing Detect Unknown Version to Default Detect Version

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
@@ -254,7 +254,7 @@ public class DetectConfiguration {
             hubOfflineMode = true;
         }
 
-        //TODO Final home for directories to exclude
+        // TODO Final home for directories to exclude
         bomToolSearchDirectoryExclusions = new ArrayList<>();
         try {
             if (bomToolSearchExclusionDefaults) {
@@ -992,7 +992,7 @@ public class DetectConfiguration {
     private String defaultProjectVersionScheme;
 
     @Value("${detect.default.project.version.text:}")
-    @DefaultValue("Detect Unknown Version")
+    @DefaultValue("Default Detect Version")
     @HelpGroup(primary = GROUP_PROJECT_INFO, additional = { SEARCH_GROUP_PROJECT })
     @HelpDescription("The text to use as the default project version")
     private String defaultProjectVersionText;


### PR DESCRIPTION
Customers are confused and concerned by our usage of the word "unknown" to describe a Detect version, so we should use a different phrase to properly communicate our message.