### PR TITLE
Code location name override

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/DetectConfiguration.java
@@ -82,7 +82,7 @@ public class DetectConfiguration {
     public static final String NUGET = "nuget";
     public static final String GRADLE = "gradle";
     public static final String DOCKER = "docker";
-    
+
     private static final String GROUP_HUB_CONFIGURATION = "hub configuration";
     private static final String GROUP_GENERAL = "general";
     private static final String GROUP_LOGGING = "logging";
@@ -608,6 +608,11 @@ public class DetectConfiguration {
     @HelpGroup(primary = GROUP_BOMTOOL)
     @HelpDescription("By default, all tools will be included. If you want to include only specific tools, specify the ones to include here. Exclusion rules always win.")
     private String includedBomToolTypes;
+
+    @Value("${detect.code.location.name:}")
+    @HelpGroup(primary = GROUP_PROJECT_INFO, additional = { SEARCH_GROUP_PROJECT })
+    @HelpDescription("An override for the name detect will use for the code location it creates. If supplied and multiple code locations are found, detect will append an index to each code location name.")
+    private String codeLocationNameOverride;
 
     @Value("${detect.project.name:}")
     @HelpGroup(primary = GROUP_PROJECT_INFO, additional = { SEARCH_GROUP_PROJECT })
@@ -1203,6 +1208,10 @@ public class DetectConfiguration {
 
     public String getProjectName() {
         return projectName == null ? null : projectName.trim();
+    }
+
+    public String getCodeLocationNameOverride() {
+        return codeLocationNameOverride == null ? null : codeLocationNameOverride.trim();
     }
 
     public String getProjectDescription() {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/BomCodeLocationNameService.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/BomCodeLocationNameService.java
@@ -39,8 +39,8 @@ import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalId;
 import com.blackducksoftware.integration.hub.detect.model.BomToolType;
 
 @Component
-public class BomCodeLocationNameFactory extends CodeLocationNameFactory {
-    private final Logger logger = LoggerFactory.getLogger(BomCodeLocationNameFactory.class);
+public class BomCodeLocationNameService extends CodeLocationNameService {
+    private final Logger logger = LoggerFactory.getLogger(BomCodeLocationNameService.class);
 
     public String createCodeLocationName(final String detectSourcePath, final String sourcePath, final ExternalId externalId, final BomToolType bomToolType, final String prefix, final String suffix) {
         //path piece

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/CodeLocationNameService.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/CodeLocationNameService.java
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.blackducksoftware.integration.hub.detect.util.DetectFileFinder;
 
-public abstract class CodeLocationNameFactory {
+public abstract class CodeLocationNameService {
     @Autowired
     protected DetectFileFinder detectFileFinder;
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/DockerCodeLocationNameService.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/DockerCodeLocationNameService.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 import com.blackducksoftware.integration.hub.detect.model.BomToolType;
 
 @Component
-public class DockerCodeLocationNameFactory extends CodeLocationNameFactory {
+public class DockerCodeLocationNameService extends CodeLocationNameService {
     public String createCodeLocationName(final String sourcePath, final String projectName, final String projectVersionName, final String dockerImage, final BomToolType bomToolType, final String prefix, final String suffix) {
         final String finalSourcePathPiece = detectFileFinder.extractFinalPieceFromPath(sourcePath);
         final String codeLocationTypeString = CodeLocationType.DOCKER.toString().toLowerCase();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/ScanCodeLocationNameService.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/codelocation/ScanCodeLocationNameService.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ScanCodeLocationNameFactory extends CodeLocationNameFactory {
+public class ScanCodeLocationNameService extends CodeLocationNameService {
     public String createCodeLocationName(final String sourcePath, final String scanTargetPath, final String projectName, final String projectVersionName, final String prefix, final String suffix) {
         final String cleanedTargetPath = cleanScanTargetPath(scanTargetPath, sourcePath);
         final String codeLocationTypeString = CodeLocationType.SCAN.toString().toLowerCase();

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/hub/HubSignatureScanner.java
@@ -49,10 +49,10 @@ import com.blackducksoftware.integration.hub.configuration.HubScanConfig;
 import com.blackducksoftware.integration.hub.configuration.HubScanConfigBuilder;
 import com.blackducksoftware.integration.hub.configuration.HubServerConfig;
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration;
-import com.blackducksoftware.integration.hub.detect.codelocation.ScanCodeLocationNameFactory;
 import com.blackducksoftware.integration.hub.detect.exception.DetectUserFriendlyException;
 import com.blackducksoftware.integration.hub.detect.exitcode.ExitCodeReporter;
 import com.blackducksoftware.integration.hub.detect.exitcode.ExitCodeType;
+import com.blackducksoftware.integration.hub.detect.manager.CodeLocationNameManager;
 import com.blackducksoftware.integration.hub.detect.model.DetectProject;
 import com.blackducksoftware.integration.hub.detect.summary.Result;
 import com.blackducksoftware.integration.hub.detect.summary.ScanSummaryResult;
@@ -84,7 +84,7 @@ public class HubSignatureScanner implements SummaryResultReporter, ExitCodeRepor
     private OfflineScanner offlineScanner;
 
     @Autowired
-    private ScanCodeLocationNameFactory scanCodeLocationNameFactory;
+    public CodeLocationNameManager codeLocationNameManager;
 
     public ProjectVersionView scanPaths(final HubServerConfig hubServerConfig, final SignatureScannerService signatureScannerService, final DetectProject detectProject)
             throws IntegrationException, DetectUserFriendlyException, InterruptedException {
@@ -250,7 +250,7 @@ public class HubSignatureScanner implements SummaryResultReporter, ExitCodeRepor
         final String sourcePath = detectConfiguration.getSourcePath();
         final String prefix = detectConfiguration.getProjectCodeLocationPrefix();
         final String suffix = detectConfiguration.getProjectCodeLocationSuffix();
-        final String codeLocationName = scanCodeLocationNameFactory.createCodeLocationName(sourcePath, canonicalPath, projectName, projectVersionName, prefix, suffix);
+        final String codeLocationName = codeLocationNameManager.createScanCodeLocationName(sourcePath, canonicalPath, projectName, projectVersionName, prefix, suffix);
         hubScanConfigBuilder.setCodeLocationAlias(codeLocationName);
 
         if (null != exclusionPatterns && !exclusionPatterns.isEmpty()) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
@@ -1,0 +1,66 @@
+package com.blackducksoftware.integration.hub.detect.manager;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.blackducksoftware.integration.hub.detect.DetectConfiguration;
+import com.blackducksoftware.integration.hub.detect.codelocation.BomCodeLocationNameService;
+import com.blackducksoftware.integration.hub.detect.codelocation.DockerCodeLocationNameService;
+import com.blackducksoftware.integration.hub.detect.codelocation.ScanCodeLocationNameService;
+import com.blackducksoftware.integration.hub.detect.model.BomToolType;
+import com.blackducksoftware.integration.hub.detect.model.DetectCodeLocation;
+
+@Component
+public class CodeLocationNameManager {
+
+    @Autowired
+    public DetectConfiguration detectConfiguration;
+
+    @Autowired
+    private BomCodeLocationNameService bomCodeLocationNameService;
+
+    @Autowired
+    private DockerCodeLocationNameService dockerCodeLocationNameService;
+
+    @Autowired
+    private ScanCodeLocationNameService scanCodeLocationNameService;
+
+    private int givenCodeLocationOverrideCount = 0;
+
+    public boolean useCodeLocationOverride() {
+        if (StringUtils.isNotBlank(detectConfiguration.getCodeLocationNameOverride())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public String getNextCodeLocationOverrideName() {
+        final String base = detectConfiguration.getCodeLocationNameOverride();
+        final String codeLocationName = base + " " + Integer.toString(givenCodeLocationOverrideCount);
+        givenCodeLocationOverrideCount++;
+        return codeLocationName;
+    }
+
+    public String createCodeLocationName(final DetectCodeLocation detectCodeLocation, final String detectSourcePath, final String projectName, final String projectVersionName,
+            final String prefix, final String suffix) {
+
+        if (useCodeLocationOverride()) {
+            return getNextCodeLocationOverrideName();
+        } else if (BomToolType.DOCKER == detectCodeLocation.getBomToolType()) {
+            return dockerCodeLocationNameService.createCodeLocationName(detectCodeLocation.getSourcePath(), projectName, projectVersionName, detectCodeLocation.getDockerImage(), detectCodeLocation.getBomToolType(), prefix, suffix);
+        } else {
+            return bomCodeLocationNameService.createCodeLocationName(detectSourcePath, detectCodeLocation.getSourcePath(), detectCodeLocation.getExternalId(), detectCodeLocation.getBomToolType(), prefix, suffix);
+        }
+    }
+
+    public String createScanCodeLocationName(final String sourcePath, final String scanTargetPath, final String projectName, final String projectVersionName, final String prefix, final String suffix) {
+        if (useCodeLocationOverride()) {
+            return getNextCodeLocationOverrideName();
+        } else {
+            return scanCodeLocationNameService.createCodeLocationName(sourcePath, scanTargetPath, projectName, projectVersionName, prefix, suffix);
+        }
+    }
+
+}

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
@@ -36,11 +36,15 @@ public class CodeLocationNameManager {
         }
     }
 
-    public String getNextCodeLocationOverrideName() {
-        final String base = detectConfiguration.getCodeLocationNameOverride();
-        final String codeLocationName = base + " " + Integer.toString(givenCodeLocationOverrideCount);
+    public String getNextCodeLocationOverrideName() { //returns "override", then "override 2", then "override 3", etc
         givenCodeLocationOverrideCount++;
-        return codeLocationName;
+        if (givenCodeLocationOverrideCount == 1) {
+            return detectConfiguration.getCodeLocationNameOverride();
+        } else {
+            final String base = detectConfiguration.getCodeLocationNameOverride();
+            final String codeLocationName = base + " " + Integer.toString(givenCodeLocationOverrideCount);
+            return codeLocationName;
+        }
     }
 
     public String createAggregateCodeLocationName() {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/CodeLocationNameManager.java
@@ -43,6 +43,14 @@ public class CodeLocationNameManager {
         return codeLocationName;
     }
 
+    public String createAggregateCodeLocationName() {
+        if (useCodeLocationOverride()) {
+            return getNextCodeLocationOverrideName();
+        } else {
+            return ""; //it is overridden in bdio creation later.
+        }
+    }
+
     public String createCodeLocationName(final DetectCodeLocation detectCodeLocation, final String detectSourcePath, final String projectName, final String projectVersionName,
             final String prefix, final String suffix) {
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/DetectBdioManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/DetectBdioManager.java
@@ -68,6 +68,9 @@ public class DetectBdioManager {
     @Autowired
     private DetectFileFinder detectFileFinder;
 
+    @Autowired
+    private CodeLocationNameManager codeLocationNameManager;
+
     public List<File> createBdioFiles(final List<BdioCodeLocation> bdioCodeLocations, final String projectName, final String projectVersion) throws DetectUserFriendlyException {
         final List<File> bdioFiles = new ArrayList<>();
         for (final BdioCodeLocation bdioCodeLocation : bdioCodeLocations) {
@@ -116,8 +119,7 @@ public class DetectBdioManager {
 
     private SimpleBdioDocument createAggregateSimpleBdioDocument(final String projectName, final String projectVersionName, final DependencyGraph dependencyGraph) {
         final ExternalId projectExternalId = simpleBdioFactory.createNameVersionExternalId(new Forge("/", "/", ""), projectName, projectVersionName);
-        String codeLocationName = "";
-
+        final String codeLocationName = codeLocationNameManager.createAggregateCodeLocationName();
         return createSimpleBdioDocument(codeLocationName, projectName, projectVersionName, projectExternalId, dependencyGraph);
     }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/DetectCodeLocationManager.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/manager/DetectCodeLocationManager.java
@@ -20,8 +20,6 @@ import com.blackducksoftware.integration.hub.bdio.graph.DependencyGraphCombiner;
 import com.blackducksoftware.integration.hub.bdio.graph.MutableDependencyGraph;
 import com.blackducksoftware.integration.hub.bdio.graph.MutableMapDependencyGraph;
 import com.blackducksoftware.integration.hub.detect.DetectConfiguration;
-import com.blackducksoftware.integration.hub.detect.codelocation.BomCodeLocationNameFactory;
-import com.blackducksoftware.integration.hub.detect.codelocation.DockerCodeLocationNameFactory;
 import com.blackducksoftware.integration.hub.detect.manager.result.codelocation.DetectCodeLocationResult;
 import com.blackducksoftware.integration.hub.detect.model.BdioCodeLocation;
 import com.blackducksoftware.integration.hub.detect.model.BomToolType;
@@ -36,10 +34,7 @@ public class DetectCodeLocationManager {
     public DetectConfiguration detectConfiguration;
 
     @Autowired
-    private BomCodeLocationNameFactory bomCodeLocationNameFactory;
-
-    @Autowired
-    private DockerCodeLocationNameFactory dockerCodeLocationNameFactory;
+    public CodeLocationNameManager codeLocationNameManager;
 
     public DetectCodeLocationResult process(final List<DetectCodeLocation> detectCodeLocations, final String projectName, final String projectVersion) {
         final Set<BomToolType> failedBomTools = new HashSet<>();
@@ -89,19 +84,10 @@ public class DetectCodeLocationManager {
         return bdioCodeLocations.stream().collect(Collectors.groupingBy(it -> it.codeLocationName, Collectors.toList()));
     }
 
-    public String createCodeLocationName(final DetectCodeLocation detectCodeLocation, final BomCodeLocationNameFactory bomCodeLocationNameFactory, final DockerCodeLocationNameFactory dockerCodeLocationNameFactory, final String detectSourcePath, final String projectName, final String projectVersionName,
-            final String prefix, final String suffix) {
-        if (BomToolType.DOCKER == detectCodeLocation.getBomToolType()) {
-            return dockerCodeLocationNameFactory.createCodeLocationName(detectCodeLocation.getSourcePath(), projectName, projectVersionName, detectCodeLocation.getDockerImage(), detectCodeLocation.getBomToolType(), prefix, suffix);
-        } else {
-            return bomCodeLocationNameFactory.createCodeLocationName(detectSourcePath, detectCodeLocation.getSourcePath(), detectCodeLocation.getExternalId(), detectCodeLocation.getBomToolType(), prefix, suffix);
-        }
-    }
-
     private Map<DetectCodeLocation, String> createCodeLocationNameMap(final List<DetectCodeLocation> codeLocations, final String detectSourcePath, final String projectName, final String projectVersion, final String prefix, final String suffix) {
         final Map<DetectCodeLocation, String> nameMap = new HashMap<>();
         for (final DetectCodeLocation detectCodeLocation : codeLocations) {
-            final String codeLocationName = createCodeLocationName(detectCodeLocation, bomCodeLocationNameFactory, dockerCodeLocationNameFactory, detectSourcePath, projectName, projectVersion, prefix, suffix);
+            final String codeLocationName = codeLocationNameManager.createCodeLocationName(detectCodeLocation, detectSourcePath, projectName, projectVersion, prefix, suffix);
             nameMap.put(detectCodeLocation, codeLocationName);
         }
         return nameMap;
@@ -165,7 +151,8 @@ public class DetectCodeLocationManager {
                     for (int i = 0; i < codeLocationsForName.size(); i++) {
                         final DetectCodeLocation codeLocation = codeLocationsForName.get(i);
                         final String suffix = " " + Integer.toString(i);
-                        final BdioCodeLocation bdioCodeLocation = new BdioCodeLocation(codeLocation, codeLocationName + suffix, createBdioName(codeLocationName, integrationEscapeUtil) + suffix);
+                        final String newCodeLocationName = codeLocationName + suffix;
+                        final BdioCodeLocation bdioCodeLocation = new BdioCodeLocation(codeLocation, newCodeLocationName, createBdioName(newCodeLocationName, integrationEscapeUtil));
                         bdioCodeLocations.add(bdioCodeLocation);
                     }
                 }

--- a/src/test/groovy/com/blackducksoftware/integration/hub/detect/CodeLocationNameFactoryTest.groovy
+++ b/src/test/groovy/com/blackducksoftware/integration/hub/detect/CodeLocationNameFactoryTest.groovy
@@ -17,8 +17,8 @@ import org.junit.Test
 
 import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalId
 import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalIdFactory
-import com.blackducksoftware.integration.hub.detect.codelocation.BomCodeLocationNameFactory
-import com.blackducksoftware.integration.hub.detect.codelocation.ScanCodeLocationNameFactory
+import com.blackducksoftware.integration.hub.detect.codelocation.BomCodeLocationNameService
+import com.blackducksoftware.integration.hub.detect.codelocation.ScanCodeLocationNameService
 import com.blackducksoftware.integration.hub.detect.model.BomToolType
 import com.blackducksoftware.integration.hub.detect.util.DetectFileFinder
 
@@ -28,7 +28,7 @@ class CodeLocationNameFactoryTest {
         String expected = 'hub-common-rest/target/hub-common-rest/2.5.1-SNAPSHOT scan'
 
         DetectFileFinder detectFileManager = [extractFinalPieceFromPath: { 'hub-common-rest' }] as DetectFileFinder
-        ScanCodeLocationNameFactory scanCodeLocationNameFactory = new ScanCodeLocationNameFactory()
+        ScanCodeLocationNameService scanCodeLocationNameFactory = new ScanCodeLocationNameService()
         scanCodeLocationNameFactory.detectFileFinder = detectFileManager
 
         String sourcePath = '/Users/ekerwin/Documents/source/integration/hub-common-rest'
@@ -49,7 +49,7 @@ class CodeLocationNameFactoryTest {
 
         ExternalIdFactory factory = new ExternalIdFactory();
         ExternalId externalId = factory.createMavenExternalId("group", "name", "version");
-        BomCodeLocationNameFactory bomCodeLocationNameFactory = new BomCodeLocationNameFactory()
+        BomCodeLocationNameService bomCodeLocationNameFactory = new BomCodeLocationNameService()
 
         String sourcePath = '/Users/ekerwin/Documents/source/integration/hub-common-rest'
         String codeLocationPath = '/Users/ekerwin/Documents/source/integration/hub-common-rest/child'
@@ -68,7 +68,7 @@ class CodeLocationNameFactoryTest {
 
         ExternalIdFactory factory = new ExternalIdFactory();
         ExternalId externalId = factory.createMavenExternalId("group", "name", "version");
-        BomCodeLocationNameFactory bomCodeLocationNameFactory = new BomCodeLocationNameFactory()
+        BomCodeLocationNameService bomCodeLocationNameFactory = new BomCodeLocationNameService()
 
         String sourcePath = '/Users/ekerwin/Documents/source/integration/hub-common-rest'
         String codeLocationPath = '/Users/ekerwin/Documents/source/integration/hub-common-rest/hub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-resthub-common-rest'


### PR DESCRIPTION
Adding a code location name manager (which is similar to the past code location name service unfortunately) and the code location factories are now services. The new manager handles incrementing previously given override names and choosing the correct factory for a code location name. 