### PR TITLE
Gradle project and version parsing fix.

### DIFF
--- a/src/main/groovy/com/blackducksoftware/integration/hub/detect/extraction/bomtool/gradle/parse/GradleReportParser.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/detect/extraction/bomtool/gradle/parse/GradleReportParser.java
@@ -118,7 +118,7 @@ public class GradleReportParser {
 
         final ExternalId id = externalIdFactory.createMavenExternalId(projectGroup, projectName, projectVersionName);
         final DetectCodeLocation detectCodeLocation = new DetectCodeLocation.Builder(BomToolType.GRADLE, projectSourcePath, id, graph).build();
-        return new GradleParseResult(projectName, projectVersionName, detectCodeLocation);
+        return new GradleParseResult(rootProjectName, rootProjectVersionName, detectCodeLocation);
     }
 
     private void clearState() {


### PR DESCRIPTION
The change to remove detect project from the bom tools was done incorrectly in the Gradle parser. 