### PR TITLE
Updating to fix the Hub 4.7.0 delay

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/BeanConfiguration.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/BeanConfiguration.java
@@ -397,7 +397,7 @@ public class BeanConfiguration {
 
     @Bean
     public HubManager hubManager() {
-        return new HubManager(bdioUploader(), hubSignatureScanner(), policyChecker(), hubServiceWrapper(), detectConfigWrapper());
+        return new HubManager(bdioUploader(), codeLocationNameManager(), detectConfigWrapper(), hubServiceWrapper(), hubSignatureScanner(), policyChecker());
     }
 
     @Bean

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/project/BdioManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/project/BdioManager.java
@@ -113,7 +113,7 @@ public class BdioManager {
 
     private SimpleBdioDocument createAggregateSimpleBdioDocument(final String projectName, final String projectVersionName, final DependencyGraph dependencyGraph) {
         final ExternalId projectExternalId = simpleBdioFactory.createNameVersionExternalId(new Forge("/", "/", ""), projectName, projectVersionName);
-        final String codeLocationName = codeLocationNameManager.createAggregateCodeLocationName();
+        final String codeLocationName = codeLocationNameManager.createAggregateCodeLocationName(projectName, projectVersionName);
         return createSimpleBdioDocument(codeLocationName, projectName, projectVersionName, projectExternalId, dependencyGraph);
     }
 


### PR DESCRIPTION
Storing the code location names and waiting for those code locations explicitly when doing a policy check or report