### PR TITLE
Preserve multi-word parameters #298.  Use TEMP and JAVA_HOME.

### DIFF
--- a/hub-detect/src/main/resources/hub-detect-sh
+++ b/hub-detect/src/main/resources/hub-detect-sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+tempdir="${TEMP:-/tmp}"
+javahome=${JAVA_HOME}
+if [[ "${OSTYPE}" == "cygwin" ]] ; then
+  tempdirnative=$(cygpath -wa "${tempdir}")
+  if (( ${#javahome} )) ; then
+    javahomeposix=$(cygpath -ua "${javahome}")
+  fi
+else
+  tempdirnative=${tempdir}
+  javahomeposix="${javahome}"
+fi
+if (( ${#javahome} )) ; then
+  export PATH="${javahomeposix}/bin:${PATH}"
+fi
+
 # DETECT_LATEST_RELEASE_VERSION should be set in your
 # environment if you wish to use a version different
 # from LATEST.
@@ -13,10 +28,10 @@ DETECT_RELEASE_VERSION=${DETECT_LATEST_RELEASE_VERSION}
 # a new commit is added to the master branch.
 DETECT_USE_SNAPSHOT=${DETECT_USE_SNAPSHOT:-0}
 
-# To override the default location of /tmp, specify
-# your own DETECT_JAR_PATH in your environment and
-# *that* location will be used.
-DETECT_JAR_PATH=${DETECT_JAR_PATH:-/tmp}
+# DETECT_JAR_PATH overrides the location to store the 
+# downloaded Hub Detect JAR.  It defaults to
+# ${TEMP:-/tmp}.
+DETECT_JAR_PATH=${DETECT_JAR_PATH:-${tempdirnative}}
 
 # If you want to pass any java options to the
 # invocation, specify DETECT_JAVA_OPTS in your
@@ -27,27 +42,21 @@ DETECT_JAVA_OPTS=${DETECT_JAVA_OPTS:-}
 # If you want to pass any additional options to
 # curl, specify DETECT_CURL_OPTS in your environment.
 # For example, to specify a proxy, you would set
-# DETECT_CURL_OPTS=--proxy http://myproxy:3128
+# DETECT_CURL_OPTS="--proxy http://myproxy:3128"
 DETECT_CURL_OPTS=${DETECT_CURL_OPTS:-}
 
-SCRIPT_ARGS="$@"
-LOGGABLE_SCRIPT_ARGS=""
-
-for i in $*; do
-  if [[ $i == --blackduck.hub.password=* ]]; then
-    LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.hub.password=<redacted>"
-  elif [[ $i == --blackduck.hub.proxy.password=* ]]; then
-    LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.hub.proxy.password=<redacted>"
-  elif [[ $i == --blackduck.hub.api.token=* ]]; then
-    LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.hub.api.token=<redacted>"
-  else
-    LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS $i"
+script_args=("$@")
+loggable_script_args=()
+for arg in "${script_args[@]}" ; do
+  if [[ "${arg}" =~ ^(.*\.(password|token)[^=]*)=.* ]] ; then
+    arg="${BASH_REMATCH[1]}=<redacted>"
   fi
+  loggable_script_args+=("${arg}")
 done
 
 run() {
   get_detect
-  run_detect
+  run_detect || return $?
 }
 
 get_detect() {
@@ -57,63 +66,53 @@ get_detect() {
     CURRENT_VERSION=$( <$VERSION_FILE_DESTINATION )
   fi
 
-  curl $DETECT_CURL_OPTS -o $VERSION_FILE_DESTINATION https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
-  LATEST_VERSION=$( <$VERSION_FILE_DESTINATION )
+  curl -sSL $DETECT_CURL_OPTS -o "${VERSION_FILE_DESTINATION}" https://blackducksoftware.github.io/hub-detect/latest-commit-id.txt
+  LATEST_VERSION=$(<"${VERSION_FILE_DESTINATION}")
 
   if [ $DETECT_USE_SNAPSHOT -eq 1 ]; then
     if [ -z "${DETECT_RELEASE_VERSION}" ]; then
-      echo "will look for snapshot: hub-detect-latest-SNAPSHOT.jar"
       DETECT_SOURCE="https://test-repo.blackducksoftware.com/artifactory/bds-integrations-snapshot/com/blackducksoftware/integration/hub-detect/latest-SNAPSHOT/hub-detect-latest-SNAPSHOT.jar"
       DETECT_DESTINATION="${DETECT_JAR_PATH}/hub-detect-latest-SNAPSHOT.jar"
+      echo "will look for snapshot: ${DETECT_SOURCE}" >&2
     else
       DETECT_SOURCE="https://test-repo.blackducksoftware.com/artifactory/bds-integrations-snapshot/com/blackducksoftware/integration/hub-detect/${DETECT_RELEASE_VERSION}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
       DETECT_DESTINATION="${DETECT_JAR_PATH}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
+      echo "will look for release: ${DETECT_SOURCE}" >&2
     fi
   else
     if [ -z "${DETECT_RELEASE_VERSION}" ]; then
-      DETECT_RELEASE_VERSION=$(curl $DETECT_CURL_OPTS 'https://test-repo.blackducksoftware.com/artifactory/api/search/latestVersion?g=com.blackducksoftware.integration&a=hub-detect&repos=bds-integrations-release')
+      DETECT_RELEASE_VERSION=$(curl -sSL $DETECT_CURL_OPTS 'https://test-repo.blackducksoftware.com/artifactory/api/search/latestVersion?g=com.blackducksoftware.integration&a=hub-detect&repos=bds-integrations-release')
       DETECT_SOURCE="https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/hub-detect/${DETECT_RELEASE_VERSION}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
       DETECT_DESTINATION="${DETECT_JAR_PATH}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
     else
       DETECT_SOURCE="https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/hub-detect/${DETECT_RELEASE_VERSION}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
       DETECT_DESTINATION="${DETECT_JAR_PATH}/hub-detect-${DETECT_RELEASE_VERSION}.jar"
     fi
-    echo "will look for : ${DETECT_SOURCE}"
+    echo "will look for release: ${DETECT_SOURCE}" >&2
   fi
 
   USE_REMOTE=1
   if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ $DETECT_USE_SNAPSHOT -eq 1 ]; then
-    echo "You don't have the latest snapshot, so the new snapshot will be downloaded."
+    echo "You don't have the latest snapshot, so the new snapshot will be downloaded." >&2
   elif [ ! -f $DETECT_DESTINATION ]; then
-    echo "You don't have the current file, so it will be downloaded."
+    echo "You don't have the current file, so it will be downloaded." >&2
   else
-    echo "You have already downloaded the latest file, so the local file will be used."
+    echo "You have already downloaded the latest file, so the local file will be used." >&2
     USE_REMOTE=0
   fi
 
   if [ $USE_REMOTE -eq 1 ]; then
-    echo "getting ${DETECT_SOURCE} from remote"
-    curl $DETECT_CURL_OPTS -L -o $DETECT_DESTINATION "${DETECT_SOURCE}"
-    echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}"
+    echo "getting ${DETECT_SOURCE} from remote" >&2
+    curl -sSL $DETECT_CURL_OPTS -o "${DETECT_DESTINATION}" "${DETECT_SOURCE}"
+    echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}" >&2
   fi
 }
 
 run_detect() {
-  JAVACMD="java ${DETECT_JAVA_OPTS} -jar ${DETECT_DESTINATION}"
-  echo "running detect: ${JAVACMD} ${LOGGABLE_SCRIPT_ARGS}"
-
-  # first, silently delete (-f ignores missing
-  # files) any existing shell script, then create
-  # the one we will run
-  rm -f $DETECT_JAR_PATH/hub-detect-java.sh
-  echo "#!/bin/sh" >> $DETECT_JAR_PATH/hub-detect-java.sh
-  echo "" >> $DETECT_JAR_PATH/hub-detect-java.sh
-  echo $JAVACMD $SCRIPT_ARGS >> $DETECT_JAR_PATH/hub-detect-java.sh
-  source $DETECT_JAR_PATH/hub-detect-java.sh
-  RESULT=$?
-  echo "Result code of ${RESULT}, exiting"
-  rm -f $DETECT_JAR_PATH/hub-detect-java.sh
-  exit $RESULT
+  javacmd=(java ${DETECT_JAVA_OPTS} -jar "${DETECT_DESTINATION}")
+  type -a java || return -1
+  echo "running detect: ${javacmd[*]@Q} ${loggable_script_args[*]@Q}" >&2
+  "${javacmd[@]}" "${script_args[@]}" || return $?
 }
 
 run


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* https://github.com/blackducksoftware/hub-detect/issues/298

**Changes proposed in this pull request:**

* Preserve arrays.
* Use TEMP and JAVA_HOME.
* Convert TEMP and JAVA_HOME to the native and POSIX format, respectively, on Cygwin, for use by the native Java and POSIX Bash, respectively.