### PR TITLE
fixing pip-inspector.py to work with pip v10+ (including v18)

### DIFF
--- a/hub-detect/src/main/resources/pip-inspector.py
+++ b/hub-detect/src/main/resources/pip-inspector.py
@@ -26,7 +26,9 @@ import os
 import sys
 import getopt
 import pip
-if pip.__version__[:2] == '10':
+
+pip_major_version = int(pip.__version__[:2])
+if pip_major_version >= 10:
     from pip._internal.req import parse_requirements
     from pip._internal.download import PipSession
 else:


### PR DESCRIPTION
# Pull Request template

**Why this pull request:**
* See https://jira.dc1.lan/browse/IDETECT-832
* pip v18 which was released Sunday, July 22, broke the hub-detect's pip-inspector.py and will cause hub-detect to fail - when run on python projects that use pip v18.

**Changes proposed in this pull request:**
* This pull request proposes a (more future proof) fix for pip-inspector.py that works with pip 10, pip 18, and, assuming the pip team sticks with numerically ascending major version numbers going forward, should work for future versions as well. Assuming that the API endpoints we use in pip do not change also.