### PR TITLE
creating an alternative to detect configuration being everywhere

### DIFF
--- a/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectConfiguration.java
+++ b/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectConfiguration.java
@@ -66,6 +66,8 @@ public class DetectConfiguration {
                 }
             }
         });
+
+        DetectProperty.setDetectConfiguration(this);
     }
 
     // TODO: Remove in version 6.

--- a/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
@@ -66,7 +66,6 @@ import com.blackducksoftware.integration.hub.detect.help.HelpDetailed;
 import com.blackducksoftware.integration.hub.detect.help.HelpGroup;
 
 public enum DetectProperty {
-
     @HelpGroup(primary = GROUP_GENERAL)
     @HelpDescription("If true, detect will always exit with code 0.")
     DETECT_FORCE_SUCCESS("detect.force.success", DetectPropertyType.BOOLEAN, "false"),
@@ -758,9 +757,15 @@ public enum DetectProperty {
     @HelpGroup(primary = GROUP_YARN)
     DETECT_YARN_PROD_ONLY("detect.yarn.prod.only", DetectPropertyType.BOOLEAN, "false");
 
+    private static DetectConfiguration detectConfiguration;
+
     private final String propertyName;
     private final DetectPropertyType propertyType;
     private final String defaultValue;
+
+    public static void setDetectConfiguration(DetectConfiguration detectConfiguration) {
+        DetectProperty.detectConfiguration = detectConfiguration;
+    }
 
     DetectProperty(final String propertyName, final DetectPropertyType propertyType) {
         this.propertyName = propertyName;
@@ -792,6 +797,26 @@ public enum DetectProperty {
             defaultValue = getDefaultValue();
         }
         return value.equals(defaultValue);
+    }
+
+    public boolean getBooleanValue() {
+        return detectConfiguration.getBooleanProperty(this);
+    }
+
+    public Long getLongValue() {
+        return detectConfiguration.getLongProperty(this);
+    }
+
+    public Integer getIntegerValue() {
+        return detectConfiguration.getIntegerProperty(this);
+    }
+
+    public String[] getStringArrayValue() {
+        return detectConfiguration.getStringArrayProperty(this);
+    }
+
+    public String getStringValue() {
+        return detectConfiguration.getPropertyValueAsString(this);
     }
 
     public final class PropertyConstants {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistParser.java
@@ -63,8 +63,8 @@ public class PackagistParser {
         final NameVersion projectNameVersion = parseNameVersionFromJson(composerJsonObject);
 
         final JsonObject composerLockObject = new JsonParser().parse(composerLockText).getAsJsonObject();
-        final List<PackagistPackage> models = convertJsonToModel(composerLockObject, detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PACKAGIST_INCLUDE_DEV_DEPENDENCIES));
-        final List<NameVersion> rootPackages = parseDependencies(composerJsonObject, detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PACKAGIST_INCLUDE_DEV_DEPENDENCIES));
+        final List<PackagistPackage> models = convertJsonToModel(composerLockObject, DetectProperty.DETECT_PACKAGIST_INCLUDE_DEV_DEPENDENCIES.getBooleanValue());
+        final List<NameVersion> rootPackages = parseDependencies(composerJsonObject, DetectProperty.DETECT_PACKAGIST_INCLUDE_DEV_DEPENDENCIES.getBooleanValue());
 
         models.forEach(it -> {
             final ExternalId id = externalIdFactory.createNameVersionExternalId(Forge.PACKAGIST, it.getNameVersion().getName(), it.getNameVersion().getVersion());

--- a/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistTest.java
+++ b/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/packagist/PackagistTest.java
@@ -19,6 +19,7 @@ public class PackagistTest {
     @Test
     public void packagistParserTest() throws IOException {
         final DetectConfiguration detectConfiguration = Mockito.mock(DetectConfiguration.class);
+        DetectProperty.setDetectConfiguration(detectConfiguration);
         Mockito.when(detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PACKAGIST_INCLUDE_DEV_DEPENDENCIES)).thenReturn(true);
 
         final PackagistParser packagistParser = new PackagistParser(new ExternalIdFactory(), detectConfiguration);


### PR DESCRIPTION
I was editing some code that involved some properties and thought this might be better to access property values.

The existing approach:
detectConfiguration.getLongProperty(DetectProperty.DETECT_API_TIMEOUT)

What I'm suggesting:
DetectProperty.DETECT_API_TIMEOUT.getLongValue()

In both approaches you need to know about the type of the property (Long, in this case) which seems fine.

The suggestion is a shorter, removes a dependency on detectConfiguration (which I think is desirable), but creates a headache for testing and is a little strange to set a static variable on an enum.

I don't think it is a slam duck improvement, but I'd like you guys to at least consider it to improve the legibility of the code involving properties and making it so the developer doesn't have to always focus on how tightly coupled DetectProperty and DetectConfiguration are.