### PR TITLE
Sb clang support json arguments or command441

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommand.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommand.java
@@ -29,5 +29,6 @@ import com.synopsys.integration.util.Stringable;
 public class CompileCommand extends Stringable {
     public String directory;
     public String command;
+    public String[] arguments;
     public String file;
 }

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandWrapper.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandWrapper.java
@@ -1,3 +1,26 @@
+/**
+ * hub-detect
+ *
+ * Copyright (C) 2018 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.blackducksoftware.integration.hub.detect.bomtool.clang;
 
 import org.apache.commons.lang3.StringUtils;

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandWrapper.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandWrapper.java
@@ -1,0 +1,30 @@
+package com.blackducksoftware.integration.hub.detect.bomtool.clang;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.util.Stringable;
+
+public class CompileCommandWrapper extends Stringable {
+    private final CompileCommand rawCompileCommand;
+
+    public CompileCommandWrapper(final CompileCommand rawCompileCommand) {
+        this.rawCompileCommand = rawCompileCommand;
+    }
+
+    public String getDirectory() {
+        return rawCompileCommand.directory;
+    }
+
+    public String getFile() {
+        return rawCompileCommand.file;
+    }
+
+    public String getCommand() {
+        if (StringUtils.isNotBlank(rawCompileCommand.command)) {
+            return rawCompileCommand.command;
+        } else {
+            return String.join(" ", rawCompileCommand.arguments);
+        }
+
+    }
+}

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/DependenciesListFileManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/DependenciesListFileManager.java
@@ -55,7 +55,7 @@ public class DependenciesListFileManager {
         this.executableRunner = executableRunner;
     }
 
-    public Set<String> generateDependencyFilePaths(final File workingDir, final CompileCommand compileCommand) {
+    public Set<String> generateDependencyFilePaths(final File workingDir, final CompileCommandWrapper compileCommand) {
         final Set<String> dependencyFilePaths = new HashSet<>();
         final Optional<File> depsMkFile = generate(workingDir, compileCommand);
         dependencyFilePaths.addAll(parse(depsMkFile.orElse(null)));
@@ -64,14 +64,14 @@ public class DependenciesListFileManager {
     }
 
     private Optional<File> generate(final File workingDir,
-            final CompileCommand compileCommand) {
+            final CompileCommandWrapper compileCommand) {
         final String depsMkFilename = deriveDependenciesListFilename(compileCommand);
         final File depsMkFile = new File(workingDir, depsMkFilename);
         try {
-            executableRunner.executeFromDirQuietly(new File(compileCommand.directory), getCompilerCommand(compileCommand.command),
-                    getCompilerArgsForGeneratingDepsMkFile(compileCommand.command, depsMkFile.getAbsolutePath()));
+            executableRunner.executeFromDirQuietly(new File(compileCommand.getDirectory()), getCompilerCommand(compileCommand.getCommand()),
+                    getCompilerArgsForGeneratingDepsMkFile(compileCommand.getCommand(), depsMkFile.getAbsolutePath()));
         } catch (final ExecutableRunnerException e) {
-            logger.debug(String.format("Error generating dependencies file for command '%s': %s", compileCommand.command, e.getMessage()));
+            logger.debug(String.format("Error generating dependencies file for command '%s': %s", compileCommand.getCommand(), e.getMessage()));
             return Optional.empty();
         }
         return Optional.of(depsMkFile);
@@ -110,9 +110,9 @@ public class DependenciesListFileManager {
         return dependencyFilePaths;
     }
 
-    private String deriveDependenciesListFilename(final CompileCommand compileCommand) {
+    private String deriveDependenciesListFilename(final CompileCommandWrapper compileCommand) {
         final int randomInt = random.nextInt(1) * 1000;
-        final String sourceFilenameBase = getFilenameBase(compileCommand.file);
+        final String sourceFilenameBase = getFilenameBase(compileCommand.getFile());
         return String.format(DEPS_MK_FILENAME_PATTERN, sourceFilenameBase, randomInt);
     }
 

--- a/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractorTest.java
+++ b/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractorTest.java
@@ -49,12 +49,13 @@ public class ClangExtractorTest {
 
         final File outputDir = new File("src/test/resources/clang/output");
 
-        final List<CompileCommand> compileCommands = new ArrayList<>();
+        final List<CompileCommandWrapper> compileCommands = new ArrayList<>();
         final CompileCommand compileCommand = new CompileCommand();
         compileCommand.directory = "src/test/resources/clang/source";
         compileCommand.file = "src/test/resources/clang/source/hello_world.cpp";
         compileCommand.command = "gcc hello_world.cpp";
-        compileCommands.add(compileCommand);
+        final CompileCommandWrapper compileCommandWrapper = new CompileCommandWrapper(compileCommand);
+        compileCommands.add(compileCommandWrapper);
 
         final File stdLibIncludeFile = new File("/usr/include/stdlib.h");
         final Set<String> dependencyFilePaths = new HashSet<>();
@@ -65,7 +66,7 @@ public class ClangExtractorTest {
         final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
         final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
 
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommand)).thenReturn(dependencyFilePaths);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapper)).thenReturn(dependencyFilePaths);
         Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
 
         final Gson gson = new Gson();
@@ -108,18 +109,20 @@ public class ClangExtractorTest {
 
         final File outputDir = new File("src/test/resources/clang/output");
 
-        final List<CompileCommand> compileCommands = new ArrayList<>();
+        final List<CompileCommandWrapper> compileCommands = new ArrayList<>();
         final CompileCommand compileCommandHelloWorld = new CompileCommand();
         compileCommandHelloWorld.directory = "src/test/resources/clang/source";
         compileCommandHelloWorld.file = "src/test/resources/clang/source/hello_world.cpp";
         compileCommandHelloWorld.command = "gcc hello_world.cpp";
-        compileCommands.add(compileCommandHelloWorld);
+        final CompileCommandWrapper compileCommandWrapperHelloWorld = new CompileCommandWrapper(compileCommandHelloWorld);
+        compileCommands.add(compileCommandWrapperHelloWorld);
 
         final CompileCommand compileCommandGoodbyeWorld = new CompileCommand();
         compileCommandGoodbyeWorld.directory = "src/test/resources/clang/source";
         compileCommandGoodbyeWorld.file = "src/test/resources/clang/source/goodbye_world.cpp";
         compileCommandGoodbyeWorld.command = "gcc goodbye_world.cpp";
-        compileCommands.add(compileCommandGoodbyeWorld);
+        final CompileCommandWrapper compileCommandWrapperGoodbyeWorld = new CompileCommandWrapper(compileCommandGoodbyeWorld);
+        compileCommands.add(compileCommandWrapperGoodbyeWorld);
 
         final File stdLibIncludeFile = new File("/usr/include/stdlib.h");
         final File mathIncludeFile = new File("/usr/include/math.h");
@@ -138,8 +141,8 @@ public class ClangExtractorTest {
         final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
         final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
 
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
 
         Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
 
@@ -189,4 +192,92 @@ public class ClangExtractorTest {
         }
     }
 
+    @Test
+    public void testJsonWithArgumentsNotCommand() throws IOException, ExecutableRunnerException {
+        final File outputDir = new File("src/test/resources/clang/output");
+
+        final List<CompileCommandWrapper> compileCommands = new ArrayList<>();
+        final CompileCommand compileCommandHelloWorld = new CompileCommand();
+        compileCommandHelloWorld.directory = "src/test/resources/clang/source";
+        compileCommandHelloWorld.file = "src/test/resources/clang/source/hello_world.cpp";
+        final String[] argsHello = { "gcc", "hello_world.cpp" };
+        compileCommandHelloWorld.arguments = argsHello;
+        final CompileCommandWrapper compileCommandWrapperHelloWorld = new CompileCommandWrapper(compileCommandHelloWorld);
+        compileCommands.add(compileCommandWrapperHelloWorld);
+
+        final CompileCommand compileCommandGoodbyeWorld = new CompileCommand();
+        compileCommandGoodbyeWorld.directory = "src/test/resources/clang/source";
+        compileCommandGoodbyeWorld.file = "src/test/resources/clang/source/goodbye_world.cpp";
+        final String[] argsGoodbye = { "gcc", "goodbye_world.cpp" };
+        compileCommandGoodbyeWorld.arguments = argsGoodbye;
+        final CompileCommandWrapper compileCommandWrapperGoodbyeWorld = new CompileCommandWrapper(compileCommandGoodbyeWorld);
+        compileCommands.add(compileCommandWrapperGoodbyeWorld);
+
+        final File stdLibIncludeFile = new File("/usr/include/stdlib.h");
+        final File mathIncludeFile = new File("/usr/include/math.h");
+        final Set<String> dependencyFilePathsHelloWorld = new HashSet<>();
+        dependencyFilePathsHelloWorld.add("src/test/resources/clang/source/myinclude.h");
+        dependencyFilePathsHelloWorld.add(stdLibIncludeFile.getAbsolutePath());
+        dependencyFilePathsHelloWorld.add(mathIncludeFile.getAbsolutePath());
+
+        final File pwdIncludeFile = new File("/usr/include/pwd.h");
+        final File printfIncludeFile = new File("/usr/include/printf.h");
+        final Set<String> dependencyFilePathsGoodbyeWorld = new HashSet<>();
+        dependencyFilePathsGoodbyeWorld.add(pwdIncludeFile.getAbsolutePath());
+        dependencyFilePathsGoodbyeWorld.add(printfIncludeFile.getAbsolutePath());
+
+        final ExecutableRunner executableRunner = Mockito.mock(ExecutableRunner.class);
+        final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
+        final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
+
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
+
+        Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
+
+        final Gson gson = new Gson();
+        final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        final CodeLocationAssembler codeLocationAssembler = new CodeLocationAssembler(externalIdFactory);
+        final ClangExtractor extractor = new ClangExtractor(executableRunner, gson, new DetectFileFinder(),
+                detectFileManager, dependenciesListFileManager,
+                codeLocationAssembler);
+
+        final ClangLinuxPackageManager pkgMgr = Mockito.mock(ClangLinuxPackageManager.class);
+        final File givenDir = new File("src/test/resources/clang/source/build");
+        final int depth = 1;
+        final ExtractionId extractionId = new ExtractionId(BomToolGroupType.CLANG, EXTRACTION_ID);
+        final File jsonCompilationDatabaseFile = new File("src/test/resources/clang/source/build/compile_commands_usesArguments.json");
+
+        Mockito.when(detectFileManager.getOutputDirectory(Mockito.any(ExtractionId.class))).thenReturn(outputDir);
+
+        final List<PackageDetails> packages = new ArrayList<>();
+        packages.add(new PackageDetails("testPackageName1", "testPackageVersion1", "testPackageArch1"));
+        packages.add(new PackageDetails("testPackageName2", "testPackageVersion2", "testPackageArch2"));
+
+        Mockito.when(pkgMgr.getDefaultForge()).thenReturn(Forge.CENTOS);
+        Mockito.when(pkgMgr.getPackages(Mockito.any(ExecutableRunner.class), Mockito.any(Set.class), Mockito.any(DependencyFileDetails.class))).thenReturn(packages);
+        Mockito.when(pkgMgr.getForges()).thenReturn(Arrays.asList(Forge.CENTOS, Forge.FEDORA, Forge.REDHAT));
+        final Extraction extraction = extractor.extract(pkgMgr, givenDir, depth, extractionId, jsonCompilationDatabaseFile);
+
+        final Set<Dependency> dependencies = extraction.codeLocations.get(0).getDependencyGraph().getRootDependencies();
+        assertEquals(6, dependencies.size());
+        for (final Dependency dependency : dependencies) {
+            System.out.printf("Checking dependency: %s:%s / %s\n", dependency.name, dependency.version, dependency.externalId.forge.getName());
+            final char indexChar = dependency.name.charAt(15);
+            assertTrue(indexChar == '1' || indexChar == '2' || indexChar == '3');
+
+            final String forge = dependency.externalId.forge.getName();
+            assertTrue("centos".equals(forge) || "fedora".equals(forge) || "redhat".equals(forge));
+
+            assertEquals(String.format("testPackageName%c", indexChar), dependency.name);
+            assertEquals(String.format("testPackageVersion%c", indexChar), dependency.version);
+            assertEquals(String.format("testPackageArch%c", indexChar), dependency.externalId.architecture);
+
+            assertEquals(forge, dependency.externalId.forge.getName());
+            assertEquals(null, dependency.externalId.group);
+            assertEquals(String.format("testPackageName%c", indexChar), dependency.externalId.name);
+            assertEquals(null, dependency.externalId.path);
+            assertEquals(String.format("testPackageVersion%c", indexChar), dependency.externalId.version);
+        }
+    }
 }

--- a/hub-detect/src/test/resources/clang/source/build/compile_commands_usesArguments.json
+++ b/hub-detect/src/test/resources/clang/source/build/compile_commands_usesArguments.json
@@ -1,0 +1,18 @@
+[
+ {
+  "directory": "src/test/resources/clang/source",
+  "arguments": [
+   "gcc",
+   "hello_world.cpp"
+  ],
+  "file": "src/test/resources/clang/source/hello_world.cpp"
+ },
+ {
+  "directory": "src/test/resources/clang/source",
+  "arguments": [
+   "gcc",
+   "goodbye_world.cpp"
+  ],
+  "file": "src/test/resources/clang/source/goodbye_world.cpp"
+ }
+]


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

*

**If nothing above, what is your reason for this pull request:**

* Previously we expected the command field to be present in compile_commands.json. Turns out, either commands or arguments is required; commands is not required. So I added the arguments field to the data object, and a wrapper class that will provide whichever is present when asked for it.

**Changes proposed in this pull request:**

*
*
*