### PR TITLE
deprecate pip inspector and the detect.pip.requirements.path property

### DIFF
--- a/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
@@ -500,6 +500,8 @@ public enum DetectProperty {
     @HelpDescription("Set to true if you would like to include only required packages")
     DETECT_PEAR_ONLY_REQUIRED_DEPS("detect.pear.only.required.deps", "3.0.0", DetectPropertyType.BOOLEAN, "false"),
 
+    @Deprecated
+    @DetectDeprecation(description = "The Pip inspector has been deprecated. Please use pipenv and the Pipenv Graph inspector in the future.", failInVersion = DetectMajorVersion.SIX, removeInVersion = DetectMajorVersion.SEVEN)
     @HelpGroup(primary = GROUP_PIP)
     @HelpDescription("The path of the requirements.txt file")
     DETECT_PIP_REQUIREMENTS_PATH("detect.pip.requirements.path", "3.0.0", DetectPropertyType.STRING),

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorBomTool.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/pip/PipInspectorBomTool.java
@@ -40,8 +40,11 @@ import com.blackducksoftware.integration.hub.detect.workflow.bomtool.FileNotFoun
 import com.blackducksoftware.integration.hub.detect.workflow.bomtool.InspectorNotFoundBomToolResult;
 import com.blackducksoftware.integration.hub.detect.workflow.bomtool.PassedBomToolResult;
 import com.blackducksoftware.integration.hub.detect.workflow.extraction.Extraction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PipInspectorBomTool extends BomTool {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     public static final String SETUPTOOLS_DEFAULT_FILE_NAME = "setup.py";
 
     private final DetectFileFinder fileFinder;
@@ -70,6 +73,9 @@ public class PipInspectorBomTool extends BomTool {
         final boolean hasSetups = setupFile != null;
         final boolean hasRequirements = requirementFilePath != null && StringUtils.isNotBlank(requirementFilePath);
         if (hasSetups || hasRequirements) {
+            logger.warn("------------------------------------------------------------------------------------------------------");
+            logger.warn("The Pip inspector has been deprecated. Please use pipenv and the Pipenv Graph inspector in the future.");
+            logger.warn("------------------------------------------------------------------------------------------------------");
             return new PassedBomToolResult();
         } else {
             return new FileNotFoundBomToolResult(SETUPTOOLS_DEFAULT_FILE_NAME);


### PR DESCRIPTION
Questions about these changes: What do you think of:
1. The wording of the new messages.
2. The point at which the "pip inspector is deprecated" message is logged
