### PR TITLE
Sb multithread clang extr safely

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
@@ -24,10 +24,7 @@
 package com.blackducksoftware.integration.hub.detect.bomtool.clang;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,7 +34,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +82,7 @@ public class ClangExtractor {
             final File outputDirectory = detectFileManager.getOutputDirectory(extractionId);
             logger.debug(String.format("extract() called; compileCommandsJsonFilePath: %s", jsonCompilationDatabaseFile.getAbsolutePath()));
             final Set<File> unManagedDependencyFiles = ConcurrentHashMap.newKeySet(64);
-            final List<CompileCommand> compileCommands = parseJsonCompilationDatabaseFile(jsonCompilationDatabaseFile);
+            final List<CompileCommand> compileCommands = CompileCommandsJsonFile.parseJsonCompilationDatabaseFile(gson, jsonCompilationDatabaseFile);
             final List<Dependency> bdioComponents = compileCommands.parallelStream()
                     .flatMap(compileCommandToDependencyFilePathsConverter(outputDirectory))
                     .collect(Collectors.toSet()).parallelStream()
@@ -184,12 +180,6 @@ public class ClangExtractor {
             processedDependencies.add(dependency);
             return false;
         }
-    }
-
-    public List<CompileCommand> parseJsonCompilationDatabaseFile(final File compileCommandsJsonFile) throws IOException {
-        final String compileCommandsJson = FileUtils.readFileToString(compileCommandsJsonFile, StandardCharsets.UTF_8);
-        final CompileCommandJsonData[] compileCommands = gson.fromJson(compileCommandsJson, CompileCommandJsonData[].class);
-        return Arrays.stream(compileCommands).map(rawCommand -> new CompileCommand(rawCommand)).collect(Collectors.toList());
     }
 
     private void logSummary(final List<Dependency> bdioComponents, final Set<File> unManagedDependencyFiles) {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
@@ -86,7 +86,7 @@ public class ClangExtractor {
             final File outputDirectory = detectFileManager.getOutputDirectory(extractionId);
             logger.debug(String.format("extract() called; compileCommandsJsonFilePath: %s", jsonCompilationDatabaseFile.getAbsolutePath()));
             final Set<File> unManagedDependencyFiles = ConcurrentHashMap.newKeySet(64);
-            final List<CompileCommandWrapper> compileCommands = parseJsonCompilationDatabaseFile(jsonCompilationDatabaseFile);
+            final List<CompileCommand> compileCommands = parseJsonCompilationDatabaseFile(jsonCompilationDatabaseFile);
             final List<Dependency> bdioComponents = compileCommands.parallelStream()
                     .flatMap(compileCommandToDependencyFilePathsConverter(outputDirectory))
                     .collect(Collectors.toSet()).parallelStream()
@@ -106,8 +106,8 @@ public class ClangExtractor {
         }
     }
 
-    private Function<CompileCommandWrapper, Stream<String>> compileCommandToDependencyFilePathsConverter(final File workingDir) {
-        return (final CompileCommandWrapper compileCommand) -> {
+    private Function<CompileCommand, Stream<String>> compileCommandToDependencyFilePathsConverter(final File workingDir) {
+        return (final CompileCommand compileCommand) -> {
             logger.info(String.format("Analyzing source file: %s", compileCommand.getFile()));
             final Set<String> dependencyFilePaths = dependenciesListFileManager.generateDependencyFilePaths(workingDir, compileCommand);
             return dependencyFilePaths.stream();
@@ -186,10 +186,10 @@ public class ClangExtractor {
         }
     }
 
-    public List<CompileCommandWrapper> parseJsonCompilationDatabaseFile(final File compileCommandsJsonFile) throws IOException {
+    public List<CompileCommand> parseJsonCompilationDatabaseFile(final File compileCommandsJsonFile) throws IOException {
         final String compileCommandsJson = FileUtils.readFileToString(compileCommandsJsonFile, StandardCharsets.UTF_8);
-        final CompileCommand[] compileCommands = gson.fromJson(compileCommandsJson, CompileCommand[].class);
-        return Arrays.stream(compileCommands).map(rawCommand -> new CompileCommandWrapper(rawCommand)).collect(Collectors.toList());
+        final CompileCommandJsonData[] compileCommands = gson.fromJson(compileCommandsJson, CompileCommandJsonData[].class);
+        return Arrays.stream(compileCommands).map(rawCommand -> new CompileCommand(rawCommand)).collect(Collectors.toList());
     }
 
     private void logSummary(final List<Dependency> bdioComponents, final Set<File> unManagedDependencyFiles) {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractor.java
@@ -135,10 +135,6 @@ public class ClangExtractor {
             final DependencyFileDetails dependencyFileWithMetaData = new DependencyFileDetails(fileFinder.isFileUnderDir(sourceDir, f), f);
             final Set<PackageDetails> linuxPackages = new HashSet<>(pkgMgr.getPackages(executableRunner, unManagedDependencyFiles, dependencyFileWithMetaData));
             logger.debug(String.format("Found %d packages for %s", linuxPackages.size(), f.getAbsolutePath()));
-            if (linuxPackages.size() == 0 && !dependencyFileWithMetaData.isInBuildDir()) {
-                logger.info(String.format("Adding %s to unManagedDependencyFiles", f.getAbsolutePath()));
-                unManagedDependencyFiles.add(f);
-            }
             return linuxPackages.stream();
         };
     }
@@ -171,19 +167,23 @@ public class ClangExtractor {
     }
 
     private boolean dependencyFileAlreadyProcessed(final File dependencyFile) {
-        if (processedDependencyFiles.contains(dependencyFile)) {
-            return true;
+        synchronized (processedDependencyFiles) {
+            if (processedDependencyFiles.contains(dependencyFile)) {
+                return true;
+            }
+            processedDependencyFiles.add(dependencyFile);
+            return false;
         }
-        processedDependencyFiles.add(dependencyFile);
-        return false;
     }
 
     private boolean dependencyAlreadyProcessed(final PackageDetails dependency) {
-        if (processedDependencies.contains(dependency)) {
-            return true;
+        synchronized (processedDependencies) {
+            if (processedDependencies.contains(dependency)) {
+                return true;
+            }
+            processedDependencies.add(dependency);
+            return false;
         }
-        processedDependencies.add(dependency);
-        return false;
     }
 
     public List<CompileCommandWrapper> parseJsonCompilationDatabaseFile(final File compileCommandsJsonFile) throws IOException {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangLinuxPackageManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangLinuxPackageManager.java
@@ -78,18 +78,19 @@ public abstract class ClangLinuxPackageManager {
             fileSpecificGetOwnerArgs.add(dependencyFile.getFile().getAbsolutePath());
             final ExecutableOutput queryPackageOutput = executableRunner.executeQuietly(pkgMgrCmdString, fileSpecificGetOwnerArgs);
             logger.debug(String.format("queryPackageOutput: %s", queryPackageOutput));
-            this.addToPackageList(executableRunner, dependencyDetailsList, queryPackageOutput.getStandardOutput());
-            return dependencyDetailsList;
+            addToPackageList(executableRunner, dependencyDetailsList, queryPackageOutput.getStandardOutput());
         } catch (final ExecutableRunnerException e) {
             logger.error(String.format("Error executing %s: %s", pkgMgrCmdString, e.getMessage()));
+        }
+        if (dependencyDetailsList.size() == 0) {
             if (!dependencyFile.isInBuildDir()) {
-                logger.debug(String.format("%s is not managed by %s", dependencyFile.getFile().getAbsolutePath(), pkgMgrCmdString));
+                logger.debug(String.format("%s is not managed by %s and it's outside the source dir", dependencyFile.getFile().getAbsolutePath(), pkgMgrCmdString));
                 unManagedDependencyFiles.add(dependencyFile.getFile());
             } else {
                 logger.debug(String.format("%s is not managed by %s, but it's in the source.dir", dependencyFile.getFile().getAbsolutePath(), pkgMgrCmdString));
             }
-            return dependencyDetailsList;
         }
+        return dependencyDetailsList;
     }
 
     public abstract Forge getDefaultForge();

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommand.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommand.java
@@ -23,12 +23,31 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.clang;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.synopsys.integration.util.Stringable;
 
-// Loaded from json via Gson
 public class CompileCommand extends Stringable {
-    public String directory;
-    public String command;
-    public String[] arguments;
-    public String file;
+    private final CompileCommandJsonData rawCompileCommand;
+
+    public CompileCommand(final CompileCommandJsonData rawCompileCommand) {
+        this.rawCompileCommand = rawCompileCommand;
+    }
+
+    public String getDirectory() {
+        return rawCompileCommand.directory;
+    }
+
+    public String getFile() {
+        return rawCompileCommand.file;
+    }
+
+    public String getCommand() {
+        if (StringUtils.isNotBlank(rawCompileCommand.command)) {
+            return rawCompileCommand.command;
+        } else {
+            return String.join(" ", rawCompileCommand.arguments);
+        }
+
+    }
 }

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandJsonData.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandJsonData.java
@@ -23,31 +23,12 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.clang;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.synopsys.integration.util.Stringable;
 
-public class CompileCommandWrapper extends Stringable {
-    private final CompileCommand rawCompileCommand;
-
-    public CompileCommandWrapper(final CompileCommand rawCompileCommand) {
-        this.rawCompileCommand = rawCompileCommand;
-    }
-
-    public String getDirectory() {
-        return rawCompileCommand.directory;
-    }
-
-    public String getFile() {
-        return rawCompileCommand.file;
-    }
-
-    public String getCommand() {
-        if (StringUtils.isNotBlank(rawCompileCommand.command)) {
-            return rawCompileCommand.command;
-        } else {
-            return String.join(" ", rawCompileCommand.arguments);
-        }
-
-    }
+// Loaded from json via Gson
+public class CompileCommandJsonData extends Stringable {
+    public String directory;
+    public String command;
+    public String[] arguments;
+    public String file;
 }

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandsJsonFile.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/CompileCommandsJsonFile.java
@@ -1,0 +1,43 @@
+/**
+ * hub-detect
+ *
+ * Copyright (C) 2018 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.detect.bomtool.clang;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import com.google.gson.Gson;
+
+public class CompileCommandsJsonFile {
+
+    public static List<CompileCommand> parseJsonCompilationDatabaseFile(final Gson gson, final File compileCommandsJsonFile) throws IOException {
+        final String compileCommandsJson = FileUtils.readFileToString(compileCommandsJsonFile, StandardCharsets.UTF_8);
+        final CompileCommandJsonData[] compileCommands = gson.fromJson(compileCommandsJson, CompileCommandJsonData[].class);
+        return Arrays.stream(compileCommands).map(rawCommand -> new CompileCommand(rawCommand)).collect(Collectors.toList());
+    }
+}

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/DependenciesListFileManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/DependenciesListFileManager.java
@@ -55,7 +55,7 @@ public class DependenciesListFileManager {
         this.executableRunner = executableRunner;
     }
 
-    public Set<String> generateDependencyFilePaths(final File workingDir, final CompileCommandWrapper compileCommand) {
+    public Set<String> generateDependencyFilePaths(final File workingDir, final CompileCommand compileCommand) {
         final Set<String> dependencyFilePaths = new HashSet<>();
         final Optional<File> depsMkFile = generate(workingDir, compileCommand);
         dependencyFilePaths.addAll(parse(depsMkFile.orElse(null)));
@@ -64,7 +64,7 @@ public class DependenciesListFileManager {
     }
 
     private Optional<File> generate(final File workingDir,
-            final CompileCommandWrapper compileCommand) {
+            final CompileCommand compileCommand) {
         final String depsMkFilename = deriveDependenciesListFilename(compileCommand);
         final File depsMkFile = new File(workingDir, depsMkFilename);
         try {
@@ -110,7 +110,7 @@ public class DependenciesListFileManager {
         return dependencyFilePaths;
     }
 
-    private String deriveDependenciesListFilename(final CompileCommandWrapper compileCommand) {
+    private String deriveDependenciesListFilename(final CompileCommand compileCommand) {
         final int randomInt = random.nextInt(1) * 1000;
         final String sourceFilenameBase = getFilenameBase(compileCommand.getFile());
         return String.format(DEPS_MK_FILENAME_PATTERN, sourceFilenameBase, randomInt);

--- a/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractorTest.java
+++ b/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/bomtool/clang/ClangExtractorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -49,14 +48,14 @@ public class ClangExtractorTest {
     public void testSimple() throws ExecutableRunnerException {
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
-        final CompileCommandWrapper compileCommandWrapper = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", "gcc hello_world.cpp", null);
+        final CompileCommand compileCommand = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", "gcc hello_world.cpp", null);
         final Set<String> dependencyFilePaths = createDependencyFilePaths(new File("/usr/include/stdlib.h"), new File("src/test/resources/clang/source/myinclude.h"));
 
         final ExecutableRunner executableRunner = Mockito.mock(ExecutableRunner.class);
         final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
         final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
 
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapper)).thenReturn(dependencyFilePaths);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommand)).thenReturn(dependencyFilePaths);
         Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
 
         final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
@@ -88,8 +87,8 @@ public class ClangExtractorTest {
     public void testMultipleCommandsDependenciesPackages() throws ExecutableRunnerException {
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
-        final CompileCommandWrapper compileCommandWrapperHelloWorld = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", "gcc hello_world.cpp", null);
-        final CompileCommandWrapper compileCommandWrapperGoodbyeWorld = createCompileCommand("src/test/resources/clang/source/goodbye_world.cpp", "gcc goodbye_world.cpp", null);
+        final CompileCommand compileCommandHelloWorld = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", "gcc hello_world.cpp", null);
+        final CompileCommand compileCommandGoodbyeWorld = createCompileCommand("src/test/resources/clang/source/goodbye_world.cpp", "gcc goodbye_world.cpp", null);
 
         final Set<String> dependencyFilePathsHelloWorld = createDependencyFilePaths(new File("src/test/resources/clang/source/myinclude.h"), new File("/usr/include/stdlib.h"), new File("/usr/include/math.h"));
 
@@ -99,8 +98,8 @@ public class ClangExtractorTest {
         final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
         final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
 
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
 
         Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
 
@@ -134,9 +133,9 @@ public class ClangExtractorTest {
     public void testJsonWithArgumentsNotCommand() throws ExecutableRunnerException {
 
         final String[] argsHello = { "gcc", "hello_world.cpp" };
-        final CompileCommandWrapper compileCommandWrapperHelloWorld = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", null, argsHello);
+        final CompileCommand compileCommandHelloWorld = createCompileCommand("src/test/resources/clang/source/hello_world.cpp", null, argsHello);
         final String[] argsGoodbye = { "gcc", "goodbye_world.cpp" };
-        final CompileCommandWrapper compileCommandWrapperGoodbyeWorld = createCompileCommand("src/test/resources/clang/source/goodbye_world.cpp", null, argsGoodbye);
+        final CompileCommand compileCommandGoodbyeWorld = createCompileCommand("src/test/resources/clang/source/goodbye_world.cpp", null, argsGoodbye);
 
         final Set<String> dependencyFilePathsHelloWorld = createDependencyFilePaths(new File("src/test/resources/clang/source/myinclude.h"), new File("/usr/include/stdlib.h"), new File("/usr/include/math.h"));
         final Set<String> dependencyFilePathsGoodbyeWorld = createDependencyFilePaths(new File("/usr/include/pwd.h"), new File("/usr/include/printf.h"));;
@@ -145,8 +144,8 @@ public class ClangExtractorTest {
         final DetectFileManager detectFileManager = Mockito.mock(DetectFileManager.class);
         final DependenciesListFileManager dependenciesListFileManager = Mockito.mock(DependenciesListFileManager.class);
 
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
-        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandWrapperGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandHelloWorld)).thenReturn(dependencyFilePathsHelloWorld);
+        Mockito.when(dependenciesListFileManager.generateDependencyFilePaths(outputDir, compileCommandGoodbyeWorld)).thenReturn(dependencyFilePathsGoodbyeWorld);
         Mockito.when(executableRunner.executeFromDirQuietly(Mockito.any(File.class), Mockito.anyString(), Mockito.anyList())).thenReturn(new ExecutableOutput(0, "", ""));
 
         final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
@@ -216,13 +215,13 @@ public class ClangExtractorTest {
         }
         return dependencyFilePaths;
     }
-    private CompileCommandWrapper createCompileCommand(String file, String command, String[] arguments) {
-        final CompileCommand compileCommandGoodbyeWorld = new CompileCommand();
-        compileCommandGoodbyeWorld.directory = "src/test/resources/clang/source";
-        compileCommandGoodbyeWorld.file = file;
-        compileCommandGoodbyeWorld.command = command;
-        compileCommandGoodbyeWorld.arguments = arguments;
-        return new CompileCommandWrapper(compileCommandGoodbyeWorld);
+    private CompileCommand createCompileCommand(String file, String command, String[] arguments) {
+        final CompileCommandJsonData compileCommandJsonData = new CompileCommandJsonData();
+        compileCommandJsonData.directory = "src/test/resources/clang/source";
+        compileCommandJsonData.file = file;
+        compileCommandJsonData.command = command;
+        compileCommandJsonData.arguments = arguments;
+        return new CompileCommand(compileCommandJsonData);
     }
 
 }


### PR DESCRIPTION
Clang: Fixed the cast exception (concurrency) problem by synchronizing on the (multi-threaded) set operations