### PR TITLE
Gradle inspector configureable url

### DIFF
--- a/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
@@ -772,7 +772,7 @@ public enum DetectProperty {
 
     @HelpGroup(primary = GROUP_GRADLE)
     @HelpDescription("The respository gradle should use to look for the gradle inspector")
-    DETECT_GRADLE_INSPECTOR_REPOSITORY_URL("detect.gradle.inspector.repository.url", "3.0.0", DetectPropertyType.STRING),
+    DETECT_GRADLE_INSPECTOR_REPOSITORY_URL("detect.gradle.inspector.repository.url", "3.0.0", DetectPropertyType.STRING, "https://repo1.maven.org/maven2/"),
 
     @HelpGroup(primary = GROUP_HEX)
     @HelpDescription("The path of the rebar3 executable")

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -91,7 +91,8 @@ public class GradleInspectorManager {
             if (airGapMavenMetadataFile.exists()) {
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromFile(airGapMavenMetadataFile);
             } else {
-                final String mavenMetadataUrl = "https://repo1.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml";
+                final String mavenMetadataUrl = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_REPOSITORY_URL)
+                        + "com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml";
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromUrl(mavenMetadataUrl);
             }
 
@@ -129,10 +130,7 @@ public class GradleInspectorManager {
             logger.debug(e.getMessage());
         }
 
-        final String gradleInspectorRepositoryUrl = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_REPOSITORY_URL);
-        if (StringUtils.isNotBlank(gradleInspectorRepositoryUrl)) {
-            model.put("customRepositoryUrl", gradleInspectorRepositoryUrl);
-        }
+        model.put("repositoryUrl", detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_REPOSITORY_URL));
         final Template initScriptTemplate = configuration.getTemplate("init-script-gradle.ftl");
 
         final Writer fileWriter = new FileWriter(initScriptFile);

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -91,7 +91,7 @@ public class GradleInspectorManager {
             if (airGapMavenMetadataFile.exists()) {
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromFile(airGapMavenMetadataFile);
             } else {
-                final String mavenMetadataUrl = "http://repo2.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml";
+                final String mavenMetadataUrl = "https://repo1.maven.org/maven2/com/blackducksoftware/integration/integration-gradle-inspector/maven-metadata.xml";
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromUrl(mavenMetadataUrl);
             }
 

--- a/hub-detect/src/main/resources/init-script-gradle.ftl
+++ b/hub-detect/src/main/resources/init-script-gradle.ftl
@@ -9,25 +9,20 @@ import com.blackducksoftware.integration.gradle.DependencyGatherer
 initscript {
 <#if airGapLibsPath??>
     println 'Running air gapped from ${airGapLibsPath}'
-<#elseif customRepositoryUrl??>
-    println 'Running in online mode with url: ${customRepositoryUrl}'
 <#else>
-    println 'Running in online mode'
+    println 'Running in online mode with url: ${repositoryUrl}'
 </#if>
     repositories {
 <#if airGapLibsPath??>
         flatDir {
             dirs '${airGapLibsPath}'
         }
-<#elseif customRepositoryUrl??>
+<#else>
         mavenLocal()
         maven {
             name 'UserDefinedRepository'
-            url '${customRepositoryUrl}'
+            url '${repositoryUrl}'
         }
-<#else>
-        mavenLocal()
-        mavenCentral()
 </#if>
     }
 


### PR DESCRIPTION
**Link to github issue (if applicable):**
* #349

**Changes proposed in this pull request:**

* Use HTTPS to download Gradle Inspect from Maven Central

  As hub-detect will download additional code based on the result of the retrieved metadata.xml, it make sense to use HTTPS to retrieve that metadata.xml. https://repo2.maven.org unfortunately uses a wrong certificate, so it makes sense to switch to https://repo1.maven.org.


* Use configurable Gradle Inspector URL for version resolution as well

  While it was possible to configure the URL of the repository to download the Gradle Inspector through `detect.gradle.inspector.repository.url`, checking for the most recent version was still done through hub-detect should not rely access Maven Central in case a custom URL for the repository is configured.

  In order to simplify the code and the init.gradle template and to make this a non-breaking change, the Maven Central URL is now the default of the `detect.gradle.inspector.repository.url` property, while this property is also used to do the version resolution.