### PR TITLE
Sb move gradle inspector to artifactory

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/BeanConfiguration.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/BeanConfiguration.java
@@ -23,29 +23,10 @@
  */
 package com.blackducksoftware.integration.hub.detect;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.ConfigurableEnvironment;
-
 import com.blackducksoftware.integration.hub.detect.bomtool.bitbake.BitbakeExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.bitbake.BitbakeListTasksParser;
 import com.blackducksoftware.integration.hub.detect.bomtool.bitbake.GraphParserTransformer;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.ApkPackageManager;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.ClangExtractor;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.ClangLinuxPackageManager;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.CodeLocationAssembler;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.DependenciesListFileManager;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.DpkgPackageManager;
-import com.blackducksoftware.integration.hub.detect.bomtool.clang.RpmPackageManager;
+import com.blackducksoftware.integration.hub.detect.bomtool.clang.*;
 import com.blackducksoftware.integration.hub.detect.bomtool.cocoapods.PodlockExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.cocoapods.PodlockParser;
 import com.blackducksoftware.integration.hub.detect.bomtool.conda.CondaCliExtractor;
@@ -70,11 +51,7 @@ import com.blackducksoftware.integration.hub.detect.bomtool.hex.RebarExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.maven.MavenCliExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.maven.MavenCodeLocationPackager;
 import com.blackducksoftware.integration.hub.detect.bomtool.maven.MavenExecutableFinder;
-import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmCliDependencyFinder;
-import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmCliExtractor;
-import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmExecutableFinder;
-import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmLockfileExtractor;
-import com.blackducksoftware.integration.hub.detect.bomtool.npm.NpmLockfilePackager;
+import com.blackducksoftware.integration.hub.detect.bomtool.npm.*;
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.NugetInspectorExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.NugetInspectorInstaller;
 import com.blackducksoftware.integration.hub.detect.bomtool.nuget.NugetInspectorManager;
@@ -83,22 +60,13 @@ import com.blackducksoftware.integration.hub.detect.bomtool.packagist.ComposerLo
 import com.blackducksoftware.integration.hub.detect.bomtool.packagist.PackagistParser;
 import com.blackducksoftware.integration.hub.detect.bomtool.pear.PearCliExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.pear.PearDependencyFinder;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PipInspectorExtractor;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PipInspectorManager;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PipInspectorTreeParser;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PipenvExtractor;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PipenvGraphParser;
-import com.blackducksoftware.integration.hub.detect.bomtool.pip.PythonExecutableFinder;
+import com.blackducksoftware.integration.hub.detect.bomtool.pip.*;
 import com.blackducksoftware.integration.hub.detect.bomtool.rubygems.GemlockExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.sbt.SbtResolutionCacheExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.yarn.YarnListParser;
 import com.blackducksoftware.integration.hub.detect.bomtool.yarn.YarnLockExtractor;
 import com.blackducksoftware.integration.hub.detect.bomtool.yarn.YarnLockParser;
-import com.blackducksoftware.integration.hub.detect.configuration.ConfigurationManager;
-import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
-import com.blackducksoftware.integration.hub.detect.configuration.DetectConfigurationUtility;
-import com.blackducksoftware.integration.hub.detect.configuration.DetectPropertyMap;
-import com.blackducksoftware.integration.hub.detect.configuration.DetectPropertySource;
+import com.blackducksoftware.integration.hub.detect.configuration.*;
 import com.blackducksoftware.integration.hub.detect.factory.BomToolFactory;
 import com.blackducksoftware.integration.hub.detect.help.ArgumentStateParser;
 import com.blackducksoftware.integration.hub.detect.help.DetectOptionManager;
@@ -120,18 +88,10 @@ import com.blackducksoftware.integration.hub.detect.workflow.PhoneHomeManager;
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.CodeLocationNameManager;
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.CodeLocationNameService;
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.DetectCodeLocationManager;
-import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.DetectRunManager;
-import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.DiagnosticFileManager;
-import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.DiagnosticLogManager;
-import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.DiagnosticManager;
-import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.DiagnosticReportManager;
+import com.blackducksoftware.integration.hub.detect.workflow.diagnostic.*;
 import com.blackducksoftware.integration.hub.detect.workflow.extraction.ExtractionManager;
 import com.blackducksoftware.integration.hub.detect.workflow.extraction.StandardExecutableFinder;
-import com.blackducksoftware.integration.hub.detect.workflow.hub.BdioUploader;
-import com.blackducksoftware.integration.hub.detect.workflow.hub.BlackDuckBinaryScanner;
-import com.blackducksoftware.integration.hub.detect.workflow.hub.BlackDuckSignatureScanner;
-import com.blackducksoftware.integration.hub.detect.workflow.hub.HubManager;
-import com.blackducksoftware.integration.hub.detect.workflow.hub.PolicyChecker;
+import com.blackducksoftware.integration.hub.detect.workflow.hub.*;
 import com.blackducksoftware.integration.hub.detect.workflow.profiling.BomToolProfiler;
 import com.blackducksoftware.integration.hub.detect.workflow.project.BdioManager;
 import com.blackducksoftware.integration.hub.detect.workflow.project.BomToolNameVersionDecider;
@@ -156,8 +116,18 @@ import com.synopsys.integration.hub.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.util.CleanupZipExpander;
 import com.synopsys.integration.util.IntegrationEscapeUtil;
-
 import freemarker.template.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.ArrayList;
+import java.util.List;
 
 @org.springframework.context.annotation.Configuration
 public class BeanConfiguration {
@@ -610,7 +580,7 @@ public class BeanConfiguration {
 
     @Bean
     public GradleInspectorManager gradleInspectorManager() throws ParserConfigurationException {
-        return new GradleInspectorManager(detectFileManager(), configuration(), detectConfiguration(), mavenMetadataService());
+        return new GradleInspectorManager(detectFileManager(), configuration(), detectConfiguration(), detectConfigurationUtility(), mavenMetadataService());
     }
 
     @Bean

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
@@ -54,8 +54,7 @@ import java.util.Optional;
 
 public class DockerInspectorManager {
     private static final String IMAGE_INSPECTOR_FAMILY = "blackduck-imageinspector-ws";
-    // TODO change to: https://repo.blackducksoftware.com/artifactory/
-    private static final String ARTIFACTORY_URL_BASE = "https://test-repo.blackducksoftware.com:443/artifactory/bds-integrations-release/com/synopsys/integration/blackduck-docker-inspector/";
+    private static final String ARTIFACTORY_URL_BASE = "https://repo.blackducksoftware.com/artifactory/bds-integrations-release/com/synopsys/integration/blackduck-docker-inspector/";
     private static final String ARTIFACTORY_URL_METADATA = ARTIFACTORY_URL_BASE + "maven-metadata.xml";
     private static final String ARTIFACTORY_URL_JAR_PATTERN = ARTIFACTORY_URL_BASE + "%s/%s";
     private static final List<String> inspectorNames = Arrays.asList("ubuntu", "alpine", "centos");

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 
 public class DockerInspectorManager {
     private static final String IMAGE_INSPECTOR_FAMILY = "blackduck-imageinspector-ws";
+    // TODO change to: https://repo.blackducksoftware.com/artifactory/
     private static final String ARTIFACTORY_URL_BASE = "https://test-repo.blackducksoftware.com:443/artifactory/bds-integrations-release/com/synopsys/integration/blackduck-docker-inspector/";
     private static final String ARTIFACTORY_URL_METADATA = ARTIFACTORY_URL_BASE + "maven-metadata.xml";
     private static final String ARTIFACTORY_URL_JAR_PATTERN = ARTIFACTORY_URL_BASE + "%s/%s";

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
@@ -23,6 +23,21 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.docker;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfigurationUtility;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectProperty;
@@ -37,20 +52,6 @@ import com.synopsys.integration.rest.connection.UnauthenticatedRestConnection;
 import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.request.Response;
 import com.synopsys.integration.util.ResourceUtil;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 public class DockerInspectorManager {
     private static final String IMAGE_INSPECTOR_FAMILY = "blackduck-imageinspector-ws";
@@ -73,7 +74,7 @@ public class DockerInspectorManager {
     private boolean hasResolvedInspector;
 
     public DockerInspectorManager(final DetectFileManager detectFileManager, final DetectFileFinder detectFileFinder,
-            final DetectConfiguration detectConfiguration, final DetectConfigurationUtility detectConfigurationUtility, final MavenMetadataService mavenMetadataService) {
+        final DetectConfiguration detectConfiguration, final DetectConfigurationUtility detectConfigurationUtility, final MavenMetadataService mavenMetadataService) {
         this.detectFileManager = detectFileManager;
         this.detectFileFinder = detectFileFinder;
         this.detectConfiguration = detectConfiguration;

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/docker/DockerInspectorManager.java
@@ -23,21 +23,6 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.docker;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfigurationUtility;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectProperty;
@@ -52,6 +37,20 @@ import com.synopsys.integration.rest.connection.UnauthenticatedRestConnection;
 import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.request.Response;
 import com.synopsys.integration.util.ResourceUtil;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 public class DockerInspectorManager {
     private static final String IMAGE_INSPECTOR_FAMILY = "blackduck-imageinspector-ws";
@@ -85,8 +84,8 @@ public class DockerInspectorManager {
     public DockerInspectorInfo getDockerInspector() throws BomToolException {
         try {
             if (!hasResolvedInspector) {
-                resolvedInfo = install();
                 hasResolvedInspector = true;
+                resolvedInfo = install();
             }
             return resolvedInfo;
         } catch (final Exception e) {
@@ -182,7 +181,7 @@ public class DockerInspectorManager {
     private File findOrDownloadJar() throws DetectUserFriendlyException {
         logger.debug("Looking for / downloading docker inspector jar file");
         final String resolvedVersion = resolveInspectorVersion();
-        final String jarFilename = this.getJarFilename(resolvedVersion);
+        final String jarFilename = getJarFilename(resolvedVersion);
         final File inspectorDirectory = detectFileManager.getSharedDirectory(dockerSharedDirectoryName);
         final File jarFile = new File(inspectorDirectory, jarFilename);
         if (jarFile.exists()) {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorExtractor.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorExtractor.java
@@ -23,6 +23,16 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.gradle;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackducksoftware.integration.hub.detect.bomtool.BomToolType;
 import com.blackducksoftware.integration.hub.detect.bomtool.ExtractionId;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
@@ -35,15 +45,6 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.DetectCodeLocation;
 import com.blackducksoftware.integration.hub.detect.workflow.extraction.Extraction;
 import com.synopsys.integration.util.NameVersion;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 public class GradleInspectorExtractor {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -55,7 +56,7 @@ public class GradleInspectorExtractor {
     private final DetectConfiguration detectConfiguration;
 
     public GradleInspectorExtractor(final ExecutableRunner executableRunner, final DetectFileFinder detectFileFinder, final DetectFileManager detectFileManager,
-            final GradleReportParser gradleReportParser, final DetectConfiguration detectConfiguration) {
+        final GradleReportParser gradleReportParser, final DetectConfiguration detectConfiguration) {
         this.executableRunner = executableRunner;
         this.detectFileFinder = detectFileFinder;
         this.detectFileManager = detectFileManager;
@@ -91,10 +92,10 @@ public class GradleInspectorExtractor {
                 String projectVersion = null;
                 if (codeLocationFiles != null) {
                     codeLocationFiles.stream()
-                            .map(codeLocationFile -> gradleReportParser.parseDependencies(bomToolType, codeLocationFile))
-                            .filter(Optional::isPresent)
-                            .map(Optional::get)
-                            .forEach(codeLocations::add);
+                        .map(codeLocationFile -> gradleReportParser.parseDependencies(bomToolType, codeLocationFile))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .forEach(codeLocations::add);
 
                     if (rootProjectMetadataFile != null) {
                         final Optional<NameVersion> projectNameVersion = gradleReportParser.parseRootProjectNameVersion(rootProjectMetadataFile);

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorExtractor.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorExtractor.java
@@ -23,16 +23,6 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.gradle;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.blackducksoftware.integration.hub.detect.bomtool.BomToolType;
 import com.blackducksoftware.integration.hub.detect.bomtool.ExtractionId;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
@@ -45,6 +35,15 @@ import com.blackducksoftware.integration.hub.detect.util.executable.ExecutableRu
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.DetectCodeLocation;
 import com.blackducksoftware.integration.hub.detect.workflow.extraction.Extraction;
 import com.synopsys.integration.util.NameVersion;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 public class GradleInspectorExtractor {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -80,7 +79,6 @@ public class GradleInspectorExtractor {
             arguments.add(String.format("-DGRADLEEXTRACTIONDIR=%s", outputDirectory.getCanonicalPath()));
             arguments.add("--info");
 
-            // logger.info("using " + gradleInspectorManager.getInitScriptPath() + " as the path for the gradle init script");
             final Executable executable = new Executable(directory, gradleExe, arguments);
             final ExecutableOutput output = executableRunner.execute(executable);
 

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -53,8 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class GradleInspectorManager {
-    // TODO change to: https://repo.blackducksoftware.com/artifactory/
-    private static final String DEFAULT_GRADLE_INSPECTOR_REPO_URL = "https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/";
+    private static final String DEFAULT_GRADLE_INSPECTOR_REPO_URL = "https://repo.blackducksoftware.com/artifactory/bds-integrations-release/";
     private static final String VERSION_METADATA_XML_FILENAME = "maven-metadata.xml";
     private static final String GRADLE_INSPECTOR_PACKAGE_PATH = "com/blackducksoftware/integration/integration-gradle-inspector/";
     private static final String RELATIVE_PATH_TO_VERSION_METADATA = GRADLE_INSPECTOR_PACKAGE_PATH + VERSION_METADATA_XML_FILENAME;
@@ -181,15 +180,12 @@ public class GradleInspectorManager {
         try {
             if (gradleInspectorAirGapDirectory != null) {
                 gradleScriptData.put("airGapLibsPath", StringEscapeUtils.escapeJava(gradleInspectorAirGapDirectory.getCanonicalPath()));
-                return;
-            } else {
-                gradleScriptData.put("gradleInspectorDirPath", inspectorDirPath);
+                return; // airgap has everything
             }
         } catch (final Exception e) {
             logger.debug(String.format("Exception encountered when resolving air gap path for gradle, running in online mode instead: %s", e.getMessage()));
         }
-        // TODO: refactor? Split?
-        String jarRepoUrl = DEFAULT_GRADLE_INSPECTOR_REPO_URL;
+        gradleScriptData.put("gradleInspectorDirPath", inspectorDirPath);
         gradleScriptData.put("integrationRepositoryUrl", DEFAULT_GRADLE_INSPECTOR_REPO_URL);
         final String configuredGradleInspectorRepositoryUrl = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_REPOSITORY_URL);
         if (StringUtils.isNotBlank(configuredGradleInspectorRepositoryUrl)) {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -95,10 +95,9 @@ public class GradleInspectorManager {
             if (airGapMavenMetadataFile.exists()) {
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromFile(airGapMavenMetadataFile);
             } else {
-                final String mavenMetadataUrl = DEFAULT_GRADLE_INSPECTOR_REPO_URL + RELATIVE_PATH_TO_VERSION_METADATA;
+                final String mavenMetadataUrl = deriveMavenMetadataUrl();
                 xmlDocument = mavenMetadataService.fetchXmlDocumentFromUrl(mavenMetadataUrl);
             }
-
             final Optional<String> versionFromXML = mavenMetadataService.parseVersionFromXML(xmlDocument, versionRange);
             if (versionFromXML.isPresent()) {
                 gradleInspectorVersion = versionFromXML.get();
@@ -110,6 +109,21 @@ public class GradleInspectorManager {
             logger.warn(String.format("Exception encountered when resolving latest version of Gradle Inspector, skipping resolution: %s", e.getMessage()));
         }
         return gradleInspectorVersion;
+    }
+
+    private String deriveMavenMetadataUrl() {
+        final String mavenMetadataUrl;
+        final String configuredGradleInspectorRepositoryUrl = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_REPOSITORY_URL);
+        if (StringUtils.isNotBlank(configuredGradleInspectorRepositoryUrl)) {
+            if (configuredGradleInspectorRepositoryUrl.endsWith("/")) {
+                mavenMetadataUrl = configuredGradleInspectorRepositoryUrl + RELATIVE_PATH_TO_VERSION_METADATA;
+            } else {
+                mavenMetadataUrl = configuredGradleInspectorRepositoryUrl + "/" + RELATIVE_PATH_TO_VERSION_METADATA;
+            }
+        } else {
+            mavenMetadataUrl = DEFAULT_GRADLE_INSPECTOR_REPO_URL + RELATIVE_PATH_TO_VERSION_METADATA;
+        }
+        return mavenMetadataUrl;
     }
 
     private String generateGradleScript(final String version) throws IOException, TemplateException {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class GradleInspectorManager {
+    // TODO change to: https://repo.blackducksoftware.com/artifactory/
     private static final String DEFAULT_GRADLE_INSPECTOR_REPO_URL = "https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/";
     private static final String VERSION_METADATA_XML_FILENAME = "maven-metadata.xml";
     private static final String GRADLE_INSPECTOR_PACKAGE_PATH = "com/blackducksoftware/integration/integration-gradle-inspector/";
@@ -98,7 +99,7 @@ public class GradleInspectorManager {
                 throw new BomToolException(e);
             }
         }
-        logger.debug(String.format("Derived generated gradle script path: %s", generatedGradleScriptPath));
+        logger.trace(String.format("Derived generated gradle script path: %s", generatedGradleScriptPath));
         return generatedGradleScriptPath;
     }
 
@@ -110,7 +111,7 @@ public class GradleInspectorManager {
                 gradleInspectorAirGapDirectory = null;
             }
         }
-        logger.debug(String.format("gradleInspectorAirGapDirectory: %s", gradleInspectorAirGapDirectory));
+        logger.trace(String.format("gradleInspectorAirGapDirectory: %s", gradleInspectorAirGapDirectory));
         return gradleInspectorAirGapDirectory;
     }
 
@@ -136,7 +137,7 @@ public class GradleInspectorManager {
         } catch (final IntegrationException | SAXException | IOException | DetectUserFriendlyException e) {
             logger.warn(String.format("Exception encountered when resolving latest version of Gradle Inspector, skipping resolution: %s", e.getMessage()));
         }
-        logger.debug(String.format("Derived gradle inspector version: %s", gradleInspectorVersion));
+        logger.trace(String.format("Derived gradle inspector version: %s", gradleInspectorVersion));
         return gradleInspectorVersion;
     }
 
@@ -152,13 +153,13 @@ public class GradleInspectorManager {
         } else {
             repoBaseUrl = DEFAULT_GRADLE_INSPECTOR_REPO_URL;
         }
-        logger.debug(String.format("Derived gradle inspector jar repo base URL: %s", repoBaseUrl));
+        logger.trace(String.format("Derived gradle inspector jar repo base URL: %s", repoBaseUrl));
         return repoBaseUrl;
     }
 
     private String deriveMavenMetadataUrl(String repoBaseUrl) {
         String mavenMetadataUrl = repoBaseUrl + RELATIVE_PATH_TO_VERSION_METADATA;
-        logger.debug(String.format("Derived mavenMetadataUrl: %s", mavenMetadataUrl));
+        logger.trace(String.format("Derived mavenMetadataUrl: %s", mavenMetadataUrl));
         return mavenMetadataUrl;
     }
 
@@ -172,7 +173,7 @@ public class GradleInspectorManager {
         gradleScriptData.put("includedConfigurationNames", detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INCLUDED_CONFIGURATIONS));
         addReposToGradleScriptData(gradleInspectorAirGapDirectory, gradleScriptData, inspectorDirPath);
         populateGradleScriptWithData(generatedGradleScriptFile, gradleScriptData);
-        logger.debug(String.format("Derived generatedGradleScriptFile path: %s", generatedGradleScriptFile.getCanonicalPath()));
+        logger.trace(String.format("Derived generatedGradleScriptFile path: %s", generatedGradleScriptFile.getCanonicalPath()));
         return generatedGradleScriptFile.getCanonicalPath();
     }
 
@@ -204,7 +205,7 @@ public class GradleInspectorManager {
     }
 
     private File findOrDownloadJar(File inspectorDirectory, String repoBaseUrlWithTrailingSlash, String jarVersion) throws DetectUserFriendlyException {
-        logger.debug("Looking for / downloading gradle inspector jar file");
+        logger.trace("Looking for / downloading gradle inspector jar file");
         final String jarFilename = getJarFilename(jarVersion);
         final File jarFile = new File(inspectorDirectory, jarFilename);
         if (jarFile.exists()) {
@@ -212,7 +213,7 @@ public class GradleInspectorManager {
         } else {
             downloadJar(repoBaseUrlWithTrailingSlash, jarVersion, jarFile);
         }
-        logger.debug(String.format("Found or downloaded jar: %s", jarFile.getAbsolutePath()));
+        logger.trace(String.format("Found or downloaded jar: %s", jarFile.getAbsolutePath()));
         return jarFile;
     }
 
@@ -231,12 +232,12 @@ public class GradleInspectorManager {
         } finally {
             ResourceUtil.closeQuietly(response);
         }
-        logger.debug(String.format("Downloaded gradle inspector jar: %s", jarFile.getAbsolutePath()));
+        logger.trace(String.format("Downloaded gradle inspector jar: %s", jarFile.getAbsolutePath()));
     }
 
     private String getJarFilename(final String version) {
         final String jarFilename = String.format("integration-gradle-inspector-%s.jar", version);
-        logger.debug(String.format("Derived jar filename: %s", jarFilename));
+        logger.trace(String.format("Derived jar filename: %s", jarFilename));
         return jarFilename;
     }
 }

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/bomtool/gradle/GradleInspectorManager.java
@@ -23,6 +23,23 @@
  */
 package com.blackducksoftware.integration.hub.detect.bomtool.gradle;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfiguration;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectConfigurationUtility;
 import com.blackducksoftware.integration.hub.detect.configuration.DetectProperty;
@@ -36,21 +53,10 @@ import com.synopsys.integration.rest.connection.UnauthenticatedRestConnection;
 import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.request.Response;
 import com.synopsys.integration.util.ResourceUtil;
+
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import java.io.*;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 public class GradleInspectorManager {
     private static final String DEFAULT_GRADLE_INSPECTOR_REPO_URL = "https://repo.blackducksoftware.com/artifactory/bds-integrations-release/";
@@ -73,7 +79,8 @@ public class GradleInspectorManager {
     private String generatedGradleScriptPath = null;
     private boolean hasResolvedInspector = false;
 
-    public GradleInspectorManager(final DetectFileManager detectFileManager, final Configuration configuration, final DetectConfiguration detectConfiguration, final DetectConfigurationUtility detectConfigurationUtility, final MavenMetadataService mavenMetadataService) {
+    public GradleInspectorManager(final DetectFileManager detectFileManager, final Configuration configuration, final DetectConfiguration detectConfiguration, final DetectConfigurationUtility detectConfigurationUtility,
+        final MavenMetadataService mavenMetadataService) {
         this.detectFileManager = detectFileManager;
         this.configuration = configuration;
         this.detectConfiguration = detectConfiguration;

--- a/hub-detect/src/main/resources/init-script-gradle.ftl
+++ b/hub-detect/src/main/resources/init-script-gradle.ftl
@@ -15,9 +15,11 @@ initscript {
     println 'Running in online mode'
 </#if>
     repositories {
+<#if gradleInspectorDirPath??>
         flatDir {
             dirs '${gradleInspectorDirPath}'
         }
+</#if>
 <#if airGapLibsPath??>
         flatDir {
             dirs '${airGapLibsPath}'
@@ -43,12 +45,14 @@ initscript {
     }
 
     dependencies {
+<#if gradleInspectorDirPath??>
         new File('${gradleInspectorDirPath}').eachFile {
             String fileName = it.name.find('.*\\.jar')?.replace('.jar', '')
             if (fileName) {
                 classpath name: fileName
             }
         }
+</#if>
 <#if airGapLibsPath??>
         new File('${airGapLibsPath}').eachFile {
             String fileName = it.name.find('.*\\.jar')?.replace('.jar', '')

--- a/hub-detect/src/main/resources/init-script-gradle.ftl
+++ b/hub-detect/src/main/resources/init-script-gradle.ftl
@@ -15,6 +15,9 @@ initscript {
     println 'Running in online mode'
 </#if>
     repositories {
+        flatDir {
+            dirs '${gradleInspectorDirPath}'
+        }
 <#if airGapLibsPath??>
         flatDir {
             dirs '${airGapLibsPath}'
@@ -40,6 +43,12 @@ initscript {
     }
 
     dependencies {
+        new File('${gradleInspectorDirPath}').eachFile {
+            String fileName = it.name.find('.*\\.jar')?.replace('.jar', '')
+            if (fileName) {
+                classpath name: fileName
+            }
+        }
 <#if airGapLibsPath??>
         new File('${airGapLibsPath}').eachFile {
             String fileName = it.name.find('.*\\.jar')?.replace('.jar', '')

--- a/hub-detect/src/main/resources/init-script-gradle.ftl
+++ b/hub-detect/src/main/resources/init-script-gradle.ftl
@@ -22,11 +22,19 @@ initscript {
 <#elseif customRepositoryUrl??>
         mavenLocal()
         maven {
+            name 'SynopsysIntegrationRepository'
+            url '${integrationRepositoryUrl}'
+        }
+        maven {
             name 'UserDefinedRepository'
             url '${customRepositoryUrl}'
         }
 <#else>
         mavenLocal()
+        maven {
+            name 'SynopsysIntegrationRepository'
+            url '${integrationRepositoryUrl}'
+        }
         mavenCentral()
 </#if>
     }


### PR DESCRIPTION
Now detect (not gradle) downloads the gradle inspector jar, and it by default gets it from the new bds artifactory url