### PR TITLE
Fix DetectConfigurationFactory.java

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/DetectConfigurationFactory.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/DetectConfigurationFactory.java
@@ -60,7 +60,7 @@ public class DetectConfigurationFactory {
         }
         String includedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS, PropertyAuthority.None);
         String excludedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS_EXCLUDED, PropertyAuthority.None);
-        DetectToolFilter detectToolFilter = new DetectToolFilter(excludedTools, includedTools, sigScanDisabled, swipEnabled);
+        DetectToolFilter detectToolFilter = new DetectToolFilter(includedTools, excludedTools, sigScanDisabled, swipEnabled);
 
         boolean unmapCodeLocations = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_CODELOCATION_UNMAP, PropertyAuthority.None);
         String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.None);


### PR DESCRIPTION
Greetings,

The function call will not have its intended effect because the positions of arguments in the constructor for DetectToolFilter do not match the ordering of the parameters:
* excludedTools is passed to includedTools
* includedTools is passed to excludedTools

Signed-off-by: Bryon Gloden, CISSP® <cissp@bryongloden.com>