### PR TITLE
Fix GopkgLockParser.java

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/detector/go/GopkgLockParser.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/detector/go/GopkgLockParser.java
@@ -78,7 +78,7 @@ public class GopkgLockParser {
             dependencyName = dependencyName + "/" + parsedPackageName;
         }
         if (dependencyName.startsWith("golang.org/x/")) {
-            dependencyName = dependencyName.replaceAll("golang.org/x/", "");
+            dependencyName = dependencyName.replace("golang.org/x/", "");
         }
 
         return dependencyName;


### PR DESCRIPTION
Greetings,

The . character in the pattern "golang.org/x/" can match any character because calls to **replaceAll** treat the pattern as a regular expression, which might be unexpected. That is to say, a string intended to be matched literally is instead treated as a regular expression, changing its meaning. To replace all occurrences of the literal string, use **replace** instead of **replaceAll**.

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com