### PR TITLE
Fix ZipSlip bug found by LGTM.com

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectZipUtil.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/util/DetectZipUtil.java
@@ -46,6 +46,8 @@ public class DetectZipUtil {
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
                 Path entryPath = destPath.resolve(entry.getName());
+                if (!entryPath.normalize().startsWith(dest.toPath()))
+                    throw new IOException("Zip entry contained path traversal");
                 if (entry.isDirectory()) {
                     Files.createDirectories(entryPath);
                 } else {


### PR DESCRIPTION
The unsanitized path of a zip archive entry, which may contain '..', was used
directly to resolve the destination path for the files being unzipped.

Extracting files from a malicious archive without validating that the
destination file path is within the destination directory can cause files
outside the destination directory to be overwritten.

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* This PR fixes an instance of ZipSlip that was [detected on LGTM.com](https://lgtm.com/projects/g/blackducksoftware/hub-detect/alerts/?mode=tree&tag=&ruleFocus=1506728586782)

**Changes proposed in this pull request:**

*  Verify that the normalized full path of the output file starts with a prefix that matches the destination directory

[More information about this kind of bug](https://lgtm.com/rules/1506728586782/)

There are a [bunch of other alerts](https://lgtm.com/projects/g/blackducksoftware/hub-detect/alerts/) for this project on LGTM.com that would probably be good to fix too.

*(Full disclosure: I'm part of the team behind LGTM.com)*