### PR TITLE
Added ability for users to set the project's 'Application ID' setting via a property

### DIFF
--- a/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/blackducksoftware/integration/hub/detect/configuration/DetectProperty.java
@@ -447,6 +447,10 @@ public enum DetectProperty {
     @HelpDetailed("When set to true, the following properties will be updated on the Project. Project tier (detect.project.tier) and Project Level Adjustments (detect.project.level.adjustments).\r\n The following properties will also be updated on the Version. Version notes (detect.project.version.notes), phase (detect.project.version.phase), distribution (detect.project.version.distribution)")
     DETECT_PROJECT_VERSION_UPDATE("detect.project.version.update", "4.0.0", PropertyType.BOOLEAN, PropertyAuthority.None, "false"),
 
+    @HelpGroup(primary = GROUP_PROJECT_INFO, additional = { SEARCH_GROUP_PROJECT })
+    @HelpDescription("Sets the 'Application ID' project setting")
+    DETECT_PROJECT_APPLICATION_ID("detect.project.application.id", "5.2.0", PropertyType.STRING, PropertyAuthority.None, null),
+
     @HelpGroup(primary = GROUP_POLICY_CHECK, additional = { SEARCH_GROUP_POLICY })
     @HelpDescription("A comma-separated list of policy violation severities that will fail detect. If this is not set, detect will not fail due to policy violations.")
     @AcceptableValues(value = { "ALL", "BLOCKER", "CRITICAL", "MAJOR", "MINOR", "TRIVIAL" }, caseSensitive = false, strict = false, isCommaSeparatedList = true)
@@ -883,11 +887,11 @@ public enum DetectProperty {
     private final String asOf;
     private final PropertyAuthority propertyAuthority;
 
-    DetectProperty(final String propertyName, final String asOf, final PropertyType propertyType, PropertyAuthority propertyAuthority) {
+    DetectProperty(final String propertyName, final String asOf, final PropertyType propertyType, final PropertyAuthority propertyAuthority) {
         this(propertyName, asOf, propertyType, propertyAuthority, null);
     }
 
-    DetectProperty(final String propertyName, final String asOf, final PropertyType propertyType, PropertyAuthority propertyAuthority, final String defaultValue) {
+    DetectProperty(final String propertyName, final String asOf, final PropertyType propertyType, final PropertyAuthority propertyAuthority, final String defaultValue) {
         this.propertyName = propertyName;
         this.asOf = asOf;
         this.propertyType = propertyType;

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/configuration/DetectConfigurationFactory.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/configuration/DetectConfigurationFactory.java
@@ -46,7 +46,7 @@ import com.synopsys.integration.blackduck.api.enumeration.PolicySeverityType;
 public class DetectConfigurationFactory {
     DetectConfiguration detectConfiguration;
 
-    public DetectConfigurationFactory(DetectConfiguration detectConfiguration) {
+    public DetectConfigurationFactory(final DetectConfiguration detectConfiguration) {
         this.detectConfiguration = detectConfiguration;
     }
 
@@ -55,8 +55,8 @@ public class DetectConfigurationFactory {
 
         //TODO: Fix this when deprecated properties are removed
         //This is because it is double deprecated so we must check if either property is set.
-        boolean originalPropertySet = detectConfiguration.wasPropertyActuallySet(DetectProperty.DETECT_BLACKDUCK_SIGNATURE_SCANNER_DISABLED);
-        boolean newPropertySet = detectConfiguration.wasPropertyActuallySet(DetectProperty.DETECT_HUB_SIGNATURE_SCANNER_DISABLED);
+        final boolean originalPropertySet = detectConfiguration.wasPropertyActuallySet(DetectProperty.DETECT_BLACKDUCK_SIGNATURE_SCANNER_DISABLED);
+        final boolean newPropertySet = detectConfiguration.wasPropertyActuallySet(DetectProperty.DETECT_HUB_SIGNATURE_SCANNER_DISABLED);
         if (originalPropertySet || newPropertySet) {
             sigScanDisabled = Optional.of(detectConfiguration.getBooleanProperty(DetectProperty.DETECT_BLACKDUCK_SIGNATURE_SCANNER_DISABLED, PropertyAuthority.None));
         }
@@ -65,55 +65,55 @@ public class DetectConfigurationFactory {
         if (detectConfiguration.wasPropertyActuallySet(DetectProperty.DETECT_SWIP_ENABLED)) {
             polarisEnabled = Optional.of(detectConfiguration.getBooleanProperty(DetectProperty.DETECT_SWIP_ENABLED, PropertyAuthority.None));
         }
-        String includedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS, PropertyAuthority.None);
-        String excludedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS_EXCLUDED, PropertyAuthority.None);
-        DetectToolFilter detectToolFilter = new DetectToolFilter(excludedTools, includedTools, sigScanDisabled, polarisEnabled);
+        final String includedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS, PropertyAuthority.None);
+        final String excludedTools = detectConfiguration.getProperty(DetectProperty.DETECT_TOOLS_EXCLUDED, PropertyAuthority.None);
+        final DetectToolFilter detectToolFilter = new DetectToolFilter(excludedTools, includedTools, sigScanDisabled, polarisEnabled);
 
-        boolean unmapCodeLocations = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_CODELOCATION_UNMAP, PropertyAuthority.None);
-        String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.None);
-        String preferredTools = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_TOOL, PropertyAuthority.None);
+        final boolean unmapCodeLocations = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_CODELOCATION_UNMAP, PropertyAuthority.None);
+        final String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.None);
+        final String preferredTools = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_TOOL, PropertyAuthority.None);
         return new RunOptions(unmapCodeLocations, aggregateName, preferredTools, detectToolFilter);
     }
 
     public DirectoryOptions createDirectoryOptions() {
-        String sourcePath = detectConfiguration.getProperty(DetectProperty.DETECT_SOURCE_PATH, PropertyAuthority.DirectoryManager);
-        String outputPath = detectConfiguration.getProperty(DetectProperty.DETECT_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
-        String bdioPath = detectConfiguration.getProperty(DetectProperty.DETECT_BDIO_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
-        String scanPath = detectConfiguration.getProperty(DetectProperty.DETECT_SCAN_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
+        final String sourcePath = detectConfiguration.getProperty(DetectProperty.DETECT_SOURCE_PATH, PropertyAuthority.DirectoryManager);
+        final String outputPath = detectConfiguration.getProperty(DetectProperty.DETECT_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
+        final String bdioPath = detectConfiguration.getProperty(DetectProperty.DETECT_BDIO_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
+        final String scanPath = detectConfiguration.getProperty(DetectProperty.DETECT_SCAN_OUTPUT_PATH, PropertyAuthority.DirectoryManager);
 
         return new DirectoryOptions(sourcePath, outputPath, bdioPath, scanPath);
     }
 
     public AirGapOptions createAirGapOptions() {
-        String gradleOverride = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
-        String nugetOverride = detectConfiguration.getProperty(DetectProperty.DETECT_NUGET_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
-        String dockerOverride = detectConfiguration.getProperty(DetectProperty.DETECT_DOCKER_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
+        final String gradleOverride = detectConfiguration.getProperty(DetectProperty.DETECT_GRADLE_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
+        final String nugetOverride = detectConfiguration.getProperty(DetectProperty.DETECT_NUGET_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
+        final String dockerOverride = detectConfiguration.getProperty(DetectProperty.DETECT_DOCKER_INSPECTOR_AIR_GAP_PATH, PropertyAuthority.AirGapManager);
 
         return new AirGapOptions(dockerOverride, gradleOverride, nugetOverride);
     }
 
-    public SearchOptions createSearchOptions(File directory) {
-        List<String> excludedDirectories = Arrays.asList(detectConfiguration.getStringArrayProperty(DetectProperty.DETECT_DETECTOR_SEARCH_EXCLUSION, PropertyAuthority.None));
-        boolean forceNestedSearch = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_DETECTOR_SEARCH_CONTINUE, PropertyAuthority.None);
-        int maxDepth = detectConfiguration.getIntegerProperty(DetectProperty.DETECT_DETECTOR_SEARCH_DEPTH, PropertyAuthority.None);
-        String excluded = detectConfiguration.getProperty(DetectProperty.DETECT_EXCLUDED_DETECTOR_TYPES, PropertyAuthority.None).toUpperCase();
-        String included = detectConfiguration.getProperty(DetectProperty.DETECT_INCLUDED_DETECTOR_TYPES, PropertyAuthority.None).toUpperCase();
-        DetectOverrideableFilter bomToolFilter = new DetectOverrideableFilter(excluded, included);
+    public SearchOptions createSearchOptions(final File directory) {
+        final List<String> excludedDirectories = Arrays.asList(detectConfiguration.getStringArrayProperty(DetectProperty.DETECT_DETECTOR_SEARCH_EXCLUSION, PropertyAuthority.None));
+        final boolean forceNestedSearch = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_DETECTOR_SEARCH_CONTINUE, PropertyAuthority.None);
+        final int maxDepth = detectConfiguration.getIntegerProperty(DetectProperty.DETECT_DETECTOR_SEARCH_DEPTH, PropertyAuthority.None);
+        final String excluded = detectConfiguration.getProperty(DetectProperty.DETECT_EXCLUDED_DETECTOR_TYPES, PropertyAuthority.None).toUpperCase();
+        final String included = detectConfiguration.getProperty(DetectProperty.DETECT_INCLUDED_DETECTOR_TYPES, PropertyAuthority.None).toUpperCase();
+        final DetectOverrideableFilter bomToolFilter = new DetectOverrideableFilter(excluded, included);
         return new SearchOptions(directory, excludedDirectories, forceNestedSearch, maxDepth, bomToolFilter);
     }
 
     public BdioOptions createBdioOptions() {
-        String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.None);
+        final String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.None);
         return new BdioOptions(aggregateName);
 
     }
 
-    public ProjectNameVersionOptions createProjectNameVersionOptions(String sourceDirectoryName) {
-        String overrideProjectName = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_NAME, PropertyAuthority.None);
-        String overrideProjectVersionName = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_VERSION_NAME, PropertyAuthority.None);
-        String defaultProjectVersionText = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_TEXT, PropertyAuthority.None);
-        String defaultProjectVersionScheme = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_SCHEME, PropertyAuthority.None);
-        String defaultProjectVersionFormat = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_TIMEFORMAT, PropertyAuthority.None);
+    public ProjectNameVersionOptions createProjectNameVersionOptions(final String sourceDirectoryName) {
+        final String overrideProjectName = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_NAME, PropertyAuthority.None);
+        final String overrideProjectVersionName = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_VERSION_NAME, PropertyAuthority.None);
+        final String defaultProjectVersionText = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_TEXT, PropertyAuthority.None);
+        final String defaultProjectVersionScheme = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_SCHEME, PropertyAuthority.None);
+        final String defaultProjectVersionFormat = detectConfiguration.getProperty(DetectProperty.DETECT_DEFAULT_PROJECT_VERSION_TIMEFORMAT, PropertyAuthority.None);
         return new ProjectNameVersionOptions(sourceDirectoryName, overrideProjectName, overrideProjectVersionName, defaultProjectVersionText, defaultProjectVersionScheme, defaultProjectVersionFormat);
     }
 
@@ -128,8 +128,9 @@ public class DetectConfigurationFactory {
         final Boolean forceProjectVersionUpdate = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_VERSION_UPDATE, PropertyAuthority.None);
         final String cloneVersionName = detectConfiguration.getProperty(DetectProperty.DETECT_CLONE_PROJECT_VERSION_NAME, PropertyAuthority.None);
         final String projectVersionNickname = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_VERSION_NICKNAME, PropertyAuthority.None);
+        final String applicationId = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_APPLICATION_ID, PropertyAuthority.None);
         return new DetectProjectServiceOptions(projectVersionPhase, projectVersionDistribution, projectTier, projectDescription, projectVersionNotes, cloneCategories, projectLevelAdjustments, forceProjectVersionUpdate, cloneVersionName,
-            projectVersionNickname);
+            projectVersionNickname, applicationId);
     }
 
     public BlackDuckSignatureScannerOptions createBlackDuckSignatureScannerOptions() {
@@ -151,23 +152,23 @@ public class DetectConfigurationFactory {
     }
 
     public BlackduckReportOptions createReportOptions() {
-        boolean runRiskReport = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_RISK_REPORT_PDF, PropertyAuthority.None);
-        boolean runNoticesReport = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_NOTICES_REPORT, PropertyAuthority.None);
-        String riskReportPdfPath = detectConfiguration.getProperty(DetectProperty.DETECT_RISK_REPORT_PDF_PATH, PropertyAuthority.None);
-        String noticesReportPath = detectConfiguration.getProperty(DetectProperty.DETECT_NOTICES_REPORT_PATH, PropertyAuthority.None);
+        final boolean runRiskReport = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_RISK_REPORT_PDF, PropertyAuthority.None);
+        final boolean runNoticesReport = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_NOTICES_REPORT, PropertyAuthority.None);
+        final String riskReportPdfPath = detectConfiguration.getProperty(DetectProperty.DETECT_RISK_REPORT_PDF_PATH, PropertyAuthority.None);
+        final String noticesReportPath = detectConfiguration.getProperty(DetectProperty.DETECT_NOTICES_REPORT_PATH, PropertyAuthority.None);
         return new BlackduckReportOptions(runRiskReport, runNoticesReport, riskReportPdfPath, noticesReportPath);
     }
 
     public PolicyCheckOptions createPolicyCheckOptions() {
         String policySeverities = detectConfiguration.getPropertyValueAsString(DetectProperty.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES, PropertyAuthority.None);
         policySeverities = ",";
-        List<PolicySeverityType> severitiesToFailPolicyCheck = EnumUtilExtension.parseCommaDelimitted(policySeverities.toUpperCase(), PolicySeverityType.class);
+        final List<PolicySeverityType> severitiesToFailPolicyCheck = EnumUtilExtension.parseCommaDelimitted(policySeverities.toUpperCase(), PolicySeverityType.class);
         return new PolicyCheckOptions(severitiesToFailPolicyCheck);
     }
 
     public long getTimeoutInSeconds() {
-        long timeout = detectConfiguration.getLongProperty(DetectProperty.DETECT_API_TIMEOUT, PropertyAuthority.None);
-        long timeoutInSeconds = timeout / 1000;
+        final long timeout = detectConfiguration.getLongProperty(DetectProperty.DETECT_API_TIMEOUT, PropertyAuthority.None);
+        final long timeoutInSeconds = timeout / 1000;
         return timeoutInSeconds;
     }
 }

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/lifecycle/run/RunManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/lifecycle/run/RunManager.java
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.lifecycle.run;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +64,7 @@ import com.blackducksoftware.integration.hub.detect.workflow.hub.BlackduckReport
 import com.blackducksoftware.integration.hub.detect.workflow.hub.CodeLocationWaitData;
 import com.blackducksoftware.integration.hub.detect.workflow.hub.DetectBdioUploadService;
 import com.blackducksoftware.integration.hub.detect.workflow.hub.DetectCodeLocationUnmapService;
+import com.blackducksoftware.integration.hub.detect.workflow.hub.DetectProjectMappingService;
 import com.blackducksoftware.integration.hub.detect.workflow.hub.DetectProjectService;
 import com.blackducksoftware.integration.hub.detect.workflow.hub.DetectProjectServiceOptions;
 import com.blackducksoftware.integration.hub.detect.workflow.hub.PolicyCheckOptions;
@@ -72,6 +74,7 @@ import com.blackducksoftware.integration.hub.detect.workflow.report.util.ReportC
 import com.blackducksoftware.integration.hub.detect.workflow.search.SearchOptions;
 import com.synopsys.integration.bdio.SimpleBdioFactory;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.codelocation.Result;
 import com.synopsys.integration.blackduck.codelocation.bdioupload.UploadBatchOutput;
@@ -87,37 +90,37 @@ public class RunManager {
 
     private final DetectContext detectContext;
 
-    public RunManager(DetectContext detectContext) {
+    public RunManager(final DetectContext detectContext) {
         this.detectContext = detectContext;
     }
 
     public RunResult run() throws DetectUserFriendlyException, InterruptedException, IntegrationException {
         //TODO: Better way for run manager to get dependencies so he can be tested. (And better ways of creating his objects)
-        DetectConfiguration detectConfiguration = detectContext.getBean(DetectConfiguration.class);
-        DetectConfigurationFactory detectConfigurationFactory = detectContext.getBean(DetectConfigurationFactory.class);
-        DirectoryManager directoryManager = detectContext.getBean(DirectoryManager.class);
-        EventSystem eventSystem = detectContext.getBean(EventSystem.class);
-        CodeLocationNameManager codeLocationNameManager = detectContext.getBean(CodeLocationNameManager.class);
-        BdioCodeLocationCreator bdioCodeLocationCreator = detectContext.getBean(BdioCodeLocationCreator.class);
-        ConnectionManager connectionManager = detectContext.getBean(ConnectionManager.class);
-        DetectInfo detectInfo = detectContext.getBean(DetectInfo.class);
-        ConnectivityManager connectivityManager = detectContext.getBean(ConnectivityManager.class);
+        final DetectConfiguration detectConfiguration = detectContext.getBean(DetectConfiguration.class);
+        final DetectConfigurationFactory detectConfigurationFactory = detectContext.getBean(DetectConfigurationFactory.class);
+        final DirectoryManager directoryManager = detectContext.getBean(DirectoryManager.class);
+        final EventSystem eventSystem = detectContext.getBean(EventSystem.class);
+        final CodeLocationNameManager codeLocationNameManager = detectContext.getBean(CodeLocationNameManager.class);
+        final BdioCodeLocationCreator bdioCodeLocationCreator = detectContext.getBean(BdioCodeLocationCreator.class);
+        final ConnectionManager connectionManager = detectContext.getBean(ConnectionManager.class);
+        final DetectInfo detectInfo = detectContext.getBean(DetectInfo.class);
+        final ConnectivityManager connectivityManager = detectContext.getBean(ConnectivityManager.class);
 
         if (connectivityManager.getPhoneHomeManager().isPresent()) {
             connectivityManager.getPhoneHomeManager().get().startPhoneHome();
         }
 
-        RunResult runResult = new RunResult();
-        RunOptions runOptions = detectConfigurationFactory.createRunOptions();
+        final RunResult runResult = new RunResult();
+        final RunOptions runOptions = detectConfigurationFactory.createRunOptions();
 
-        DetectToolFilter detectToolFilter = runOptions.getDetectToolFilter();
+        final DetectToolFilter detectToolFilter = runOptions.getDetectToolFilter();
 
         logger.info(ReportConstants.RUN_SEPARATOR);
         if (detectToolFilter.shouldInclude(DetectTool.DOCKER)) {
             logger.info("Will include the docker tool.");
-            DockerTool dockerTool = new DockerTool(detectContext);
+            final DockerTool dockerTool = new DockerTool(detectContext);
 
-            DockerToolResult dockerToolResult = dockerTool.run();
+            final DockerToolResult dockerToolResult = dockerTool.run();
             runResult.addToolNameVersionIfPresent(DetectTool.DOCKER, dockerToolResult.dockerProjectNameVersion);
             runResult.addDetectCodeLocations(dockerToolResult.dockerCodeLocations);
             runResult.addDockerFile(dockerToolResult.dockerTar);
@@ -133,11 +136,11 @@ public class RunManager {
         logger.info(ReportConstants.RUN_SEPARATOR);
         if (detectToolFilter.shouldInclude(DetectTool.DETECTOR)) {
             logger.info("Will include the detector tool.");
-            String projectBomTool = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_DETECTOR, PropertyAuthority.None);
-            SearchOptions searchOptions = detectConfigurationFactory.createSearchOptions(directoryManager.getSourceDirectory());
-            DetectorTool detectorTool = new DetectorTool(detectContext);
+            final String projectBomTool = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_DETECTOR, PropertyAuthority.None);
+            final SearchOptions searchOptions = detectConfigurationFactory.createSearchOptions(directoryManager.getSourceDirectory());
+            final DetectorTool detectorTool = new DetectorTool(detectContext);
 
-            DetectorToolResult detectorToolResult = detectorTool.performDetectors(searchOptions, projectBomTool);
+            final DetectorToolResult detectorToolResult = detectorTool.performDetectors(searchOptions, projectBomTool);
             runResult.addToolNameVersionIfPresent(DetectTool.DETECTOR, detectorToolResult.bomToolProjectNameVersion);
             runResult.addDetectCodeLocations(detectorToolResult.bomToolCodeLocations);
             runResult.addApplicableDetectors(detectorToolResult.applicableDetectorTypes);
@@ -155,9 +158,9 @@ public class RunManager {
 
         logger.info("Determining project info.");
 
-        ProjectNameVersionOptions projectNameVersionOptions = detectConfigurationFactory.createProjectNameVersionOptions(directoryManager.getSourceDirectory().getName());
-        ProjectNameVersionDecider projectNameVersionDecider = new ProjectNameVersionDecider(projectNameVersionOptions);
-        NameVersion projectNameVersion = projectNameVersionDecider.decideProjectNameVersion(runOptions.getPreferredTools(), runResult.getDetectToolProjectInfo());
+        final ProjectNameVersionOptions projectNameVersionOptions = detectConfigurationFactory.createProjectNameVersionOptions(directoryManager.getSourceDirectory().getName());
+        final ProjectNameVersionDecider projectNameVersionDecider = new ProjectNameVersionDecider(projectNameVersionOptions);
+        final NameVersion projectNameVersion = projectNameVersionDecider.decideProjectNameVersion(runOptions.getPreferredTools(), runResult.getDetectToolProjectInfo());
 
         logger.info("Project name: " + projectNameVersion.getName());
         logger.info("Project version: " + projectNameVersion.getVersion());
@@ -165,14 +168,22 @@ public class RunManager {
         Optional<ProjectVersionWrapper> projectVersionWrapper = Optional.empty();
 
         if (connectivityManager.isDetectOnline() && connectivityManager.getBlackDuckServicesFactory().isPresent()) {
-            BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
+            final BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
             logger.info("Getting or creating project.");
-            DetectProjectServiceOptions options = detectConfigurationFactory.createDetectProjectServiceOptions();
-            DetectProjectService detectProjectService = new DetectProjectService(blackDuckServicesFactory, options);
+            final DetectProjectServiceOptions options = detectConfigurationFactory.createDetectProjectServiceOptions();
+            final DetectProjectMappingService detectProjectMappingService = new DetectProjectMappingService(blackDuckServicesFactory.createBlackDuckService());
+            final DetectProjectService detectProjectService = new DetectProjectService(blackDuckServicesFactory, options, detectProjectMappingService);
             projectVersionWrapper = Optional.of(detectProjectService.createOrUpdateHubProject(projectNameVersion));
+
+            if (projectVersionWrapper.isPresent() && StringUtils.isNotBlank(options.getApplicationId())) {
+                logger.info("Setting project Application ID");
+                final ProjectView projectView = projectVersionWrapper.get().getProjectView();
+                detectProjectService.setApplicationId(projectView, options.getApplicationId());
+            }
+
             if (projectVersionWrapper.isPresent() && runOptions.shouldUnmapCodeLocations()) {
                 logger.info("Unmapping code locations.");
-                DetectCodeLocationUnmapService detectCodeLocationUnmapService = new DetectCodeLocationUnmapService(blackDuckServicesFactory.createBlackDuckService(), blackDuckServicesFactory.createCodeLocationService());
+                final DetectCodeLocationUnmapService detectCodeLocationUnmapService = new DetectCodeLocationUnmapService(blackDuckServicesFactory.createBlackDuckService(), blackDuckServicesFactory.createCodeLocationService());
                 detectCodeLocationUnmapService.unmapCodeLocations(projectVersionWrapper.get().getProjectVersionView());
             } else {
                 logger.debug("Will not unmap code locations: Project view was not present, or should not unmap code locations.");
@@ -184,18 +195,18 @@ public class RunManager {
         logger.info("Completed project and version actions.");
 
         logger.info("Processing Detect Code Locations.");
-        CodeLocationWaitData codeLocationWaitData = new CodeLocationWaitData();
-        BdioManager bdioManager = new BdioManager(detectInfo, new SimpleBdioFactory(), new IntegrationEscapeUtil(), codeLocationNameManager, detectConfiguration, bdioCodeLocationCreator, directoryManager, eventSystem);
-        BdioResult bdioResult = bdioManager.createBdioFiles(runOptions.getAggregateName(), projectNameVersion, runResult.getDetectCodeLocations());
+        final CodeLocationWaitData codeLocationWaitData = new CodeLocationWaitData();
+        final BdioManager bdioManager = new BdioManager(detectInfo, new SimpleBdioFactory(), new IntegrationEscapeUtil(), codeLocationNameManager, detectConfiguration, bdioCodeLocationCreator, directoryManager, eventSystem);
+        final BdioResult bdioResult = bdioManager.createBdioFiles(runOptions.getAggregateName(), projectNameVersion, runResult.getDetectCodeLocations());
 
         if (bdioResult.getUploadTargets().size() > 0) {
             logger.info("Created " + bdioResult.getUploadTargets().size() + " BDIO files.");
             bdioResult.getUploadTargets().forEach(it -> eventSystem.publishEvent(Event.OutputFileOfInterest, it.getUploadFile()));
             if (connectivityManager.isDetectOnline() && connectivityManager.getBlackDuckServicesFactory().isPresent()) {
                 logger.info("Uploading BDIO files.");
-                BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
-                DetectBdioUploadService detectBdioUploadService = new DetectBdioUploadService(detectConfiguration, blackDuckServicesFactory.createBdioUploadService());
-                CodeLocationCreationData<UploadBatchOutput> uploadBatchOutputCodeLocationCreationData = detectBdioUploadService.uploadBdioFiles(bdioResult.getUploadTargets());
+                final BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
+                final DetectBdioUploadService detectBdioUploadService = new DetectBdioUploadService(detectConfiguration, blackDuckServicesFactory.createBdioUploadService());
+                final CodeLocationCreationData<UploadBatchOutput> uploadBatchOutputCodeLocationCreationData = detectBdioUploadService.uploadBdioFiles(bdioResult.getUploadTargets());
                 codeLocationWaitData.setFromBdioCodeLocationCreationData(uploadBatchOutputCodeLocationCreationData);
             }
         } else {
@@ -207,9 +218,9 @@ public class RunManager {
         logger.info(ReportConstants.RUN_SEPARATOR);
         if (detectToolFilter.shouldInclude(DetectTool.SIGNATURE_SCAN)) {
             logger.info("Will include the signature scanner tool.");
-            BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = detectConfigurationFactory.createBlackDuckSignatureScannerOptions();
-            BlackDuckSignatureScannerTool blackDuckSignatureScannerTool = new BlackDuckSignatureScannerTool(blackDuckSignatureScannerOptions, detectContext);
-            SignatureScannerToolResult signatureScannerToolResult = blackDuckSignatureScannerTool.runScanTool(projectNameVersion, runResult.getDockerTar());
+            final BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = detectConfigurationFactory.createBlackDuckSignatureScannerOptions();
+            final BlackDuckSignatureScannerTool blackDuckSignatureScannerTool = new BlackDuckSignatureScannerTool(blackDuckSignatureScannerOptions, detectContext);
+            final SignatureScannerToolResult signatureScannerToolResult = blackDuckSignatureScannerTool.runScanTool(projectNameVersion, runResult.getDockerTar());
             if (signatureScannerToolResult.getResult() == Result.SUCCESS && signatureScannerToolResult.getCreationData().isPresent()) {
                 codeLocationWaitData.setFromSignatureScannerCodeLocationCreationData(signatureScannerToolResult.getCreationData().get());
             }
@@ -222,8 +233,8 @@ public class RunManager {
         if (detectToolFilter.shouldInclude(DetectTool.BINARY_SCAN)) {
             logger.info("Will include the binary scanner tool.");
             if (connectivityManager.isDetectOnline() && connectivityManager.getBlackDuckServicesFactory().isPresent()) {
-                BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
-                BlackDuckBinaryScannerTool blackDuckBinaryScanner = new BlackDuckBinaryScannerTool(eventSystem, codeLocationNameManager, detectConfiguration, blackDuckServicesFactory);
+                final BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
+                final BlackDuckBinaryScannerTool blackDuckBinaryScanner = new BlackDuckBinaryScannerTool(eventSystem, codeLocationNameManager, detectConfiguration, blackDuckServicesFactory);
                 blackDuckBinaryScanner.performBinaryScanActions(projectNameVersion);
             }
             logger.info("Binary scanner actions finished.");
@@ -234,7 +245,7 @@ public class RunManager {
         logger.info(ReportConstants.RUN_SEPARATOR);
         if (detectToolFilter.shouldInclude(DetectTool.POLARIS)) {
             logger.info("Will include the Polaris tool.");
-            PolarisTool polarisTool = new PolarisTool(eventSystem, directoryManager, new ExecutableRunner(), connectionManager);
+            final PolarisTool polarisTool = new PolarisTool(eventSystem, directoryManager, new ExecutableRunner(), connectionManager);
             polarisTool.runPolaris(new Slf4jIntLogger(logger), directoryManager.getSourceDirectory());
             logger.info("Polaris actions finished.");
         } else {
@@ -243,18 +254,18 @@ public class RunManager {
 
         logger.info(ReportConstants.RUN_SEPARATOR);
         if (projectVersionWrapper.isPresent() && connectivityManager.isDetectOnline() && connectivityManager.getBlackDuckServicesFactory().isPresent()) {
-            BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
+            final BlackDuckServicesFactory blackDuckServicesFactory = connectivityManager.getBlackDuckServicesFactory().get();
 
             logger.info("Will perform Black Duck post actions.");
-            BlackduckReportOptions blackduckReportOptions = detectConfigurationFactory.createReportOptions();
-            PolicyCheckOptions policyCheckOptions = detectConfigurationFactory.createPolicyCheckOptions();
-            long timeoutInSeconds = detectConfigurationFactory.getTimeoutInSeconds();
+            final BlackduckReportOptions blackduckReportOptions = detectConfigurationFactory.createReportOptions();
+            final PolicyCheckOptions policyCheckOptions = detectConfigurationFactory.createPolicyCheckOptions();
+            final long timeoutInSeconds = detectConfigurationFactory.getTimeoutInSeconds();
 
-            BlackduckPostActions blackduckPostActions = new BlackduckPostActions(blackDuckServicesFactory, eventSystem);
+            final BlackduckPostActions blackduckPostActions = new BlackduckPostActions(blackDuckServicesFactory, eventSystem);
             blackduckPostActions.perform(blackduckReportOptions, policyCheckOptions, codeLocationWaitData, projectVersionWrapper.get(), timeoutInSeconds);
 
-            boolean hasAtLeastOneBdio = !bdioResult.getUploadTargets().isEmpty();
-            boolean shouldHaveScanned = detectToolFilter.shouldInclude(DetectTool.SIGNATURE_SCAN);
+            final boolean hasAtLeastOneBdio = !bdioResult.getUploadTargets().isEmpty();
+            final boolean shouldHaveScanned = detectToolFilter.shouldInclude(DetectTool.SIGNATURE_SCAN);
 
             if (hasAtLeastOneBdio || shouldHaveScanned) {
                 final Optional<String> componentsLink = projectVersionWrapper.get().getProjectVersionView().getFirstLink(ProjectVersionView.COMPONENTS_LINK);

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/lifecycle/run/RunManager.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/lifecycle/run/RunManager.java
@@ -25,7 +25,6 @@ package com.blackducksoftware.integration.hub.detect.lifecycle.run;
 
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +73,6 @@ import com.blackducksoftware.integration.hub.detect.workflow.report.util.ReportC
 import com.blackducksoftware.integration.hub.detect.workflow.search.SearchOptions;
 import com.synopsys.integration.bdio.SimpleBdioFactory;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
-import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.codelocation.Result;
 import com.synopsys.integration.blackduck.codelocation.bdioupload.UploadBatchOutput;
@@ -173,13 +171,7 @@ public class RunManager {
             final DetectProjectServiceOptions options = detectConfigurationFactory.createDetectProjectServiceOptions();
             final DetectProjectMappingService detectProjectMappingService = new DetectProjectMappingService(blackDuckServicesFactory.createBlackDuckService());
             final DetectProjectService detectProjectService = new DetectProjectService(blackDuckServicesFactory, options, detectProjectMappingService);
-            projectVersionWrapper = Optional.of(detectProjectService.createOrUpdateHubProject(projectNameVersion));
-
-            if (projectVersionWrapper.isPresent() && StringUtils.isNotBlank(options.getApplicationId())) {
-                logger.info("Setting project Application ID");
-                final ProjectView projectView = projectVersionWrapper.get().getProjectView();
-                detectProjectService.setApplicationId(projectView, options.getApplicationId());
-            }
+            projectVersionWrapper = Optional.of(detectProjectService.createOrUpdateHubProject(projectNameVersion, options.getApplicationId()));
 
             if (projectVersionWrapper.isPresent() && runOptions.shouldUnmapCodeLocations()) {
                 logger.info("Unmapping code locations.");

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingService.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingService.java
@@ -42,7 +42,6 @@ public class DetectProjectMappingService {
 
     /**
      * Sets the applicationId for a project
-     * @return The url of the project mapping
      * @throws IntegrationException
      */
     public void setApplicationId(final ProjectView projectView, final String applicationId) throws IntegrationException {
@@ -66,6 +65,12 @@ public class DetectProjectMappingService {
         }
     }
 
+    /**
+     * Retrieves all the project-mappings from a project
+     * @param projectView for the project whose mappings you want
+     * @return A list of project-mappings that have been set
+     * @throws IntegrationException
+     */
     public List<DetectProjectMappingView> getProjectMappings(final ProjectView projectView) throws IntegrationException {
         final Optional<String> projectMappingsLink = projectView.getFirstLink(PROJECT_MAPPINGS_LINK_RESPONSE.getLink());
         if (projectMappingsLink.isPresent()) {

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingService.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingService.java
@@ -1,0 +1,91 @@
+/**
+ * hub-detect
+ *
+ * Copyright (C) 2019 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.detect.workflow.hub;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.api.core.LinkSingleResponse;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
+import com.synopsys.integration.blackduck.service.BlackDuckService;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+
+public class DetectProjectMappingService {
+    public static final LinkSingleResponse<DetectProjectMappingView> PROJECT_MAPPINGS_LINK_RESPONSE = new LinkSingleResponse<>("project-mappings", DetectProjectMappingView.class);
+
+    private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(this.getClass()));
+
+    private final BlackDuckService blackDuckService;
+
+    public DetectProjectMappingService(final BlackDuckService blackDuckService) {
+        this.blackDuckService = blackDuckService;
+    }
+
+    /**
+     * Sets the applicationId for a project
+     * @return The url of the project mapping
+     * @throws IntegrationException
+     */
+    public String setApplicationId(final ProjectView projectView, final String applicationId) throws IntegrationException {
+        final Optional<String> projectMappingsLink = projectView.getFirstLink(PROJECT_MAPPINGS_LINK_RESPONSE.getLink());
+
+        if (projectMappingsLink.isPresent()) {
+            // TODO: Currently there exists only one project-mapping which is the application id. Eventually there will be many so we need to filter
+            final Optional<DetectProjectMappingView> existingProjectMappingView = getProjectMappings(projectView).stream()
+                                                                                      .findFirst();
+            if (existingProjectMappingView.isPresent()) {
+                deleteProjectMapping(existingProjectMappingView.get());
+            }
+
+            final DetectProjectMappingView detectProjectMappingView = new DetectProjectMappingView();
+            detectProjectMappingView.setApplicationId(applicationId);
+
+            return blackDuckService.post(projectMappingsLink.get(), detectProjectMappingView);
+        } else {
+            throw new IntegrationException("project-mappings link not found in projectView");
+        }
+    }
+
+    public List<DetectProjectMappingView> getProjectMappings(final ProjectView projectView) throws IntegrationException {
+        final Optional<String> projectMappingsLink = projectView.getFirstLink(PROJECT_MAPPINGS_LINK_RESPONSE.getLink());
+        if (projectMappingsLink.isPresent()) {
+            return blackDuckService.getAllResponses(projectMappingsLink.get(), DetectProjectMappingView.class);
+        } else {
+            throw new IntegrationException("project-mappings link not found in projectView");
+        }
+    }
+
+    public void deleteProjectMapping(final DetectProjectMappingView detectProjectMappingView) throws IntegrationException {
+        final Optional<String> href = detectProjectMappingView.getHref();
+        if (href.isPresent()) {
+            blackDuckService.delete(href.get());
+        } else {
+            logger.error("Cannot delete project mapping because no href was found");
+        }
+    }
+}

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingView.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingView.java
@@ -1,0 +1,38 @@
+/**
+ * hub-detect
+ *
+ * Copyright (C) 2019 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.detect.workflow.hub;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+
+public class DetectProjectMappingView extends BlackDuckView {
+    private String applicationId;
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(final String applicationId) {
+        this.applicationId = applicationId;
+    }
+}

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingView.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectMappingView.java
@@ -25,6 +25,7 @@ package com.blackducksoftware.integration.hub.detect.workflow.hub;
 
 import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 
+// TODO: There will eventually be a namespace field
 public class DetectProjectMappingView extends BlackDuckView {
     private String applicationId;
 

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectServiceOptions.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/hub/DetectProjectServiceOptions.java
@@ -34,9 +34,10 @@ public class DetectProjectServiceOptions {
     private final Boolean forceProjectVersionUpdate;
     private final String cloneVersionName;
     private final String projectVersionNickname;
+    private final String applicationId;
 
     public DetectProjectServiceOptions(final String projectVersionPhase, final String projectVersionDistribution, final Integer projectTier, final String projectDescription, final String projectVersionNotes,
-        final String[] cloneCategories, final Boolean projectLevelAdjustments, final Boolean forceProjectVersionUpdate, final String cloneVersionName, final String projectVersionNickname) {
+        final String[] cloneCategories, final Boolean projectLevelAdjustments, final Boolean forceProjectVersionUpdate, final String cloneVersionName, final String projectVersionNickname, final String applicationId) {
         this.projectVersionPhase = projectVersionPhase;
         this.projectVersionDistribution = projectVersionDistribution;
         this.projectTier = projectTier;
@@ -47,6 +48,7 @@ public class DetectProjectServiceOptions {
         this.forceProjectVersionUpdate = forceProjectVersionUpdate;
         this.cloneVersionName = cloneVersionName;
         this.projectVersionNickname = projectVersionNickname;
+        this.applicationId = applicationId;
     }
 
     public String getProjectVersionPhase() {
@@ -87,5 +89,9 @@ public class DetectProjectServiceOptions {
 
     public String getProjectVersionNickname() {
         return projectVersionNickname;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
     }
 }


### PR DESCRIPTION
# Pull Request Template

**Link to github issue (if applicable):**
N/A

**If nothing above, what is your reason for this pull request:**
Customer's would like to set a project's Application ID when running Detect

**Changes proposed in this pull request:**
Added a DetectProjectMappingService which aids in the getting/setting/and deletion of project-mappings