### PR TITLE
bazel: generate codelocation like rubygems does, for a better codeloc…

### DIFF
--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/tool/bazel/BazelCodeLocationBuilder.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/tool/bazel/BazelCodeLocationBuilder.java
@@ -34,6 +34,7 @@ import com.blackducksoftware.integration.hub.detect.workflow.codelocation.Detect
 import com.blackducksoftware.integration.hub.detect.workflow.codelocation.DetectCodeLocationType;
 import com.synopsys.integration.bdio.graph.MutableDependencyGraph;
 import com.synopsys.integration.bdio.graph.MutableMapDependencyGraph;
+import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.dependency.Dependency;
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
@@ -67,9 +68,9 @@ public class BazelCodeLocationBuilder {
     }
 
     public List<DetectCodeLocation> build() {
-        Dependency projectDependency = gavToProject("unknown", workspaceDir.getName(), "unknown");
-        final DetectCodeLocation codeLocation = new DetectCodeLocation.Builder(DetectCodeLocationType.MAVEN, workspaceDir.getAbsolutePath(),
-            projectDependency.externalId, dependencyGraph).build();
+        Forge forge = new Forge("/", "/", "DETECT");
+         final ExternalId externalId = externalIdFactory.createPathExternalId(forge, workspaceDir.toString());
+         final DetectCodeLocation codeLocation = new DetectCodeLocation.Builder(DetectCodeLocationType.BAZEL, workspaceDir.toString(), externalId, dependencyGraph).build();
         List<DetectCodeLocation> codeLocations = new ArrayList<>(1);
         codeLocations.add(codeLocation);
         return codeLocations;

--- a/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/codelocation/DetectCodeLocationType.java
+++ b/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/workflow/codelocation/DetectCodeLocationType.java
@@ -24,6 +24,7 @@
 package com.blackducksoftware.integration.hub.detect.workflow.codelocation;
 
 public enum DetectCodeLocationType {
+    BAZEL,
     BITBAKE,
     COCOAPODS,
     CONDA,

--- a/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/tool/bazel/BazelCodeLocationBuilderTest.java
+++ b/hub-detect/src/test/groovy/com/blackducksoftware/integration/hub/detect/tool/bazel/BazelCodeLocationBuilderTest.java
@@ -21,8 +21,7 @@ public class BazelCodeLocationBuilderTest {
             .build();
 
         assertEquals(1, codeLocations.size());
-        assertEquals("multiLevel", codeLocations.get(0).getExternalId().name);
-        assertEquals("unknown", codeLocations.get(0).getExternalId().version);
+        assertEquals("src/test/resources/bazel/multiLevel", codeLocations.get(0).getExternalId().path);
         assertEquals(1, codeLocations.get(0).getDependencyGraph().getRootDependencies().size());
 
         Dependency dep = codeLocations.get(0).getDependencyGraph().getRootDependencies().iterator().next();


### PR DESCRIPTION
changed bazel tool to generate a codelocation name consistent with rubygems. Previously the codelocation name included the project name/version, and the version was unknown.
